### PR TITLE
Going to normal mode after saving instead of going to insert mode

### DIFF
--- a/vim.ahk
+++ b/vim.ahk
@@ -1345,7 +1345,7 @@ Return
 #If WinActive("ahk_group " . VimGroupName) and (VimMode == "Command_w")
 Return::
   Send, ^s
-  VimSetMode("Insert")
+  VimSetMode("Vim_Normal")
 Return
 
 q::


### PR DESCRIPTION
Steps to Reproduce:

1. Open a word document.
2. Make some changes.
3. Hit :w to save.

Expected:
The current mode should be Vim_Normal.

Actual:
The mode is insert mode which is not in line with the VIM text editor.