### PR TITLE
Fixing typo that was causing cw to stop working

### DIFF
--- a/vim.ahk
+++ b/vim.ahk
@@ -1040,7 +1040,7 @@ VimMove(key="", shift=0){
     Send, ^x
     ClipWait, 1
     VimSetMode("Vim_Normal")
-  }else if(VimMode == ="Vim_ydc_c"){
+  }else if(VimMode == "Vim_ydc_c"){
     Clipboard :=
     Send, ^x
     ClipWait, 1


### PR DESCRIPTION
Looks like there was a slight typo.  It probably worked in the past

fixes #16.