### PR TITLE
Warn if you have made a typo in a vim mode

### DIFF
--- a/vim.ahk
+++ b/vim.ahk
@@ -6,6 +6,14 @@ VimAuthor := "rcmdnk"
 VimDescription := "Vim emulation with AutoHotkey, everywhere in Windows."
 VimHomepage := "https://github.com/rcmdnk/vim_ahk"
 
+; #Warn ; Provides code warnings when running
+warn:=true ; For custom warnings/exceptions/error checking
+possibleVimModes := []
+possibleVimModes.Push("Vim_Normal", "Insert", "Replace", "Vim_ydc_y"
+, "Vim_ydc_c", "Vim_ydc_d", "Vim_VisualLine", "Vim_VisualFirst"
+, "Vim_VisualChar", "Command", "Command_w", "Command_q", "Z", ""
+, "r_once", "r_repeat", "Vim_VisualLineFirst")
+
 ; Ini file
 VimIniDir := % A_AppData . "\AutoHotkey"
 VimIni := % VimIniDir . "\vim_ahk.ini"
@@ -498,6 +506,9 @@ VimSetIcon(Mode=""){
 
 VimSetMode(Mode="", g=0, n=0, LineCopy=-1){
   global
+  if warn {
+    checkValidMode(mode)
+  }
   if(Mode != ""){
     VimMode := Mode
     If(Mode == "Insert") and (VimRestoreIME == 1){
@@ -518,6 +529,23 @@ VimSetMode(Mode="", g=0, n=0, LineCopy=-1){
   Return
 }
 
+isCurrentVimMode(mode){
+  global VimMode
+  global warn
+  if warn {
+    checkValidMode(mode)
+  }
+  return (mode == VimMode)
+}
+
+strIsInCurrentVimMode(str){
+  global VimMode
+  if warn {
+    checkValidMode(str, false)
+  }
+  return (inStr(VimMode, str))
+}
+
 VimCheckMode(verbose=1, Mode="", g=0, n=0, LineCopy=-1, force=0){
   global
 
@@ -533,6 +561,25 @@ VimCheckMode(verbose=1, Mode="", g=0, n=0, LineCopy=-1, force=0){
   }
   Return
 }
+
+checkValidMode(mode, full_match := true){
+  Global possibleVimModes
+  try {
+    inOrBlank:= (not full_match) ? "in " : ""
+    if not hasValue(possibleVimModes, mode, full_match) {
+      throw Exception("Invalid mode specified",-2,
+      ( Join
+"'" mode "' is not " inOrBlank "a valid mode as defined by the possibleVimModes
+ array at the top of vim.ahk. This may be a typo.
+ Fix this error by using an existing mode,
+ or adding your mode to the array.")
+      )
+    }
+  } catch e {
+    MsgBox % "Warning: " e.Message "`n" e.Extra "`n`n Called in " e.What " at line " e.Line
+  }
+}
+
 
 VimStatus(Title, lines=1){
   WinGetPos, , , W, H, A
@@ -611,6 +658,26 @@ VimStopStatusCheck:
   SetTimer, VimStatusCheckTimer, off
 Return
 
+hasValue(haystack, needle, full_match = true) {
+  if(!isObject(haystack)){
+    return false
+  }else if(haystack.Length()==0){
+    return false
+  }
+  for index,value in haystack{
+    if full_match{
+      if (value==needle){
+        return true
+      }
+    }else{
+      if (inStr(value, needle)){
+        return true
+      }
+    }
+  }
+  return false
+}
+
 VimAddCheckbox(name, defaultVal, description){
   global VimCheckboxesCreated
   if(VimCheckboxesCreated == 0){
@@ -668,7 +735,7 @@ Esc:: ; Just send Esc at converting, long press for normal Esc.
   VimSetNormal()
 Return
 
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode, "Insert")) and (VimJJ == 1)
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode( "Insert")) and (VimJJ == 1)
 ~j up:: ; jj: go to Normal mode.
   Input, jout, I T0.1 V L1, j
   if(ErrorLevel == "EndKey:J"){
@@ -678,7 +745,7 @@ Return
 Return
 ; }}}
 
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode, "Insert")) and (VimJK == 1)
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode( "Insert")) and (VimJK == 1)
 j & k::
 k & j::
   SendInput, {BackSpace 1}
@@ -686,7 +753,7 @@ k & j::
 Return
 ; }}}
 
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode, "Insert")) and (VimSD == 1)
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode( "Insert")) and (VimSD == 1)
 s & d::
 d & s::
   SendInput, {BackSpace 1}
@@ -728,7 +795,7 @@ Return
 ; }}}
 
 ; Repeat {{{
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode,"Vim_"))
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode("Vim_"))
 1::
 2::
 3::
@@ -742,7 +809,7 @@ Return
   VimSetMode("", 0, n_repeat)
 Return
 
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode,"Vim_")) and (Vim_n > 0)
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode("Vim_")) and (Vim_n > 0)
 0:: ; 0 is used as {Home} for Vim_n=0
   n_repeat := Vim_n*10 + A_ThisHotkey
   VimSetMode("", 0, n_repeat)
@@ -1003,17 +1070,17 @@ Return
 
 ; Move {{{
 ; g {{{
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode,"Vim_")) and (not Vim_g)
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode("Vim_")) and (not Vim_g)
 g::VimSetMode("", 1)
 ; }}}
 
 VimMove(key="", shift=0){
   global
-  if(InStr(VimMode, "Visual") or InStr(VimMode, "ydc") or shift == 1){
+  if(strIsInCurrentVimMode( "Visual") or strIsInCurrentVimMode( "ydc") or shift == 1){
     Send, {Shift Down}
   }
   ; Left/Right
-  if(not InStr(VimMode, "Line")){
+  if(not strIsInCurrentVimMode( "Line")){
     ; 1 character
     if(key == "h"){
       Send, {Left}
@@ -1038,11 +1105,11 @@ VimMove(key="", shift=0){
     Send, {Shift Up}{End}{Home}{Shift Down}{Up}
     VimSetMode("Vim_VisualLine")
   }
-  if(InStr(VimMode, "Vim_ydc")) and (key == "k" or key == "^u" or key == "^b" or key == "g"){
+  if(strIsInCurrentVimMode( "Vim_ydc")) and (key == "k" or key == "^u" or key == "^b" or key == "g"){
     VimLineCopy := 1
     Send,{Shift Up}{Home}{Down}{Shift Down}{Up}
   }
-  if(InStr(VimMode,"Vim_ydc")) and (key == "j" or key == "^d" or key == "^f" or key == "+g"){
+  if(strIsInCurrentVimMode("Vim_ydc")) and (key == "j" or key == "^d" or key == "^f" or key == "+g"){
     VimLineCopy := 1
     Send,{Shift Up}{Home}{Shift Down}{Down}
   }
@@ -1105,7 +1172,7 @@ VimMoveLoop(key="", shift=0){
     VimMove(key, shift)
   }
 }
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode,"Vim_"))
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode("Vim_"))
 ; 1 character
 h::VimMoveLoop("h")
 j::VimMoveLoop("j")
@@ -1136,7 +1203,7 @@ b::VimMoveLoop("b")
 ; G
 +g::VimMove("+g")
 ; gg
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode, "Vim_")) and (Vim_g)
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode( "Vim_")) and (Vim_g)
 g::VimMove("g")
 ; }}} Move
 
@@ -1297,14 +1364,14 @@ Return
 Return
 
 ; ydc
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode, "Visual"))
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode( "Visual"))
 y::
   Clipboard :=
   Send, ^c
   Send, {Right}
   Send, {Left}
   ClipWait, 1
-  if(InStr(VimMode, "Line")){
+  if(strIsInCurrentVimMode( "Line")){
     VimSetMode("Vim_Normal", 0, 0, 1)
   }else{
     VimSetMode("Vim_Normal", 0, 0, 0)
@@ -1315,7 +1382,7 @@ d::
   Clipboard :=
   Send, ^x
   ClipWait, 1
-  if(InStr(VimMode,"Line")){
+  if(strIsInCurrentVimMode("Line")){
     VimSetMode("Vim_Normal", 0, 0, 1)
   }else{
     VimSetMode("Vim_Normal", 0, 0, 0)
@@ -1326,7 +1393,7 @@ x::
   Clipboard :=
   Send, ^x
   ClipWait, 1
-  if(InStr(VimMode, "Line")){
+  if(strIsInCurrentVimMode( "Line")){
     VimSetMode("Vim_Normal", 0, 0, 1)
   }else{
     VimSetMode("Vim_Normal", 0, 0, 0)
@@ -1337,7 +1404,7 @@ c::
   Clipboard :=
   Send, ^x
   ClipWait, 1
-  if(InStr(VimMode, "Line")){
+  if(strIsInCurrentVimMode( "Line")){
     VimSetMode("Insert", 0, 0, 1)
   }else{
     VimSetMode("Insert", 0, 0, 0)
@@ -1415,7 +1482,7 @@ Return
 ; }}} Vim command mode
 
 ; Disable other keys {{{
-#If WinActive("ahk_group " . VimGroupName) and (InStr(VimMode, "ydc") or InStr(VimMode, "Command") or (VimMode == "Z"))
+#If WinActive("ahk_group " . VimGroupName) and (strIsInCurrentVimMode( "ydc") or strIsInCurrentVimMode( "Command") or (VimMode == "Z"))
 *a::
 *b::
 *c::
@@ -1486,7 +1553,7 @@ Space::
   VimSetMode("Vim_Normal")
 Return
 
-#If WinActive("ahk_group " . VimGroupName) and InStr(VimMode,"Vim_") and (VimDisableUnused == 2)
+#If WinActive("ahk_group " . VimGroupName) and strIsInCurrentVimMode("Vim_") and (VimDisableUnused == 2)
 a::
 b::
 c::
@@ -1582,7 +1649,7 @@ _::
 Space::
 Return
 
-#If WinActive("ahk_group " . VimGroupName) and InStr(VimMode,"Vim_") and (VimDisableUnused == 3)
+#If WinActive("ahk_group " . VimGroupName) and strIsInCurrentVimMode("Vim_") and (VimDisableUnused == 3)
 *a::
 *b::
 *c::

--- a/vim.ahk
+++ b/vim.ahk
@@ -1427,7 +1427,7 @@ Return
 #If WinActive("ahk_group " . VimGroupName) and (VimMode == "Vim_Normal")
 /::
   Send, ^f
-  VimSetMode("Inseret")
+  VimSetMode("Insert")
 Return
 
 *::
@@ -1438,7 +1438,7 @@ Return
   Send, ^f
   Send, ^v!f
   clipboard := bak
-  VimSetMode("Inseret")
+  VimSetMode("Insert")
 Return
 
 n::Send, {F3}


### PR DESCRIPTION
Adds and implements a function for checking and setting the current
mode, and ensuring it matches a pre-defined array of possible modes.
It can be disabled by a varible at the top of the script.

This should prevent issues like [this one](https://github.com/rcmdnk/vim_ahk/blob/60a4136f81b9310c02050920bb782d2a1baedd3c/vim.ahk#L1363)