### PR TITLE
Make J&K or S&D options generic (can use any letter combination)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 testLogs/
-.DS_Store
+!lib/

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ vim_ahk also works on other applications which use these Class/Process name (mos
 |:-----|:----------|:------|
 |VimRestoreIME|If 1, IME status is restored at entering insert mode.|1|
 |VimJJ|If 1, `jj` changes mode to Normal from Insert.|0|
-|VimJK|If 1, `jk` changes mode to Normal from Insert.|0|
-|VimSD|If 1, `sd` changes mode to Normal from Insert.|0|
+|VimTwoLetterEsc|A list of character pairs to press together during insert mode to get to normal mode. For example, a value of `jk` means pressing `j` and `k` at the same time will enter normal mode.||
+|VimIcon|If 1, task tray icon is changed when mode is changed.|1|
 |VimDisableUnused|Disable level of unused keys in Normal mode (see below for details).|3|
 |VimSetTitleMatchMode|SetTitleMatchMode: 1: Start with, 2: Contain, 3: Exact match|2|
 |VimSetTitleMatchModeFS|SetTitleMatchMode: Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow|Fast|
@@ -151,15 +151,14 @@ After pressing `:`, a few commands to save/quit are available.
 |Key/Commands|Function|
 |:----------:|:-------|
 |ESC/Ctrl-[| Enter Normal Mode. Holding (0.5s) these keys emulate normal ESC.|
-|jj|Enter Normal Mode.|
-|jk|Enter Normal Mode.|
-|sd|Enter Normal Mode.|
+|jj|Enter Normal Mode, if enabled.|
+|Custom two letters|If two-letter mapping is set|
 
 ESC/Ctrl-[ switch off IME if IME is on.
 ESC acts as ESC when IME is on and converting instructions.
 Ctrl-[ switches off IME and enters Normal Mode even if IME is on.
 
-jj, jk or sd is optional one, which is enabled when VimJJ/VimJK/VimSK = 1, respectively.
+If using a custom two-letter hotkey to enter normal mode, the two letters must be different.
 
 ## Available commands in Normal Mode
 ### Mode Change

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -9,6 +9,14 @@ Esc:: ; Just send Esc at converting, long press for normal Esc.
   Vim.State.SetNormal()
 Return
 
+#If
+; This function called by hotkeys specified in settings load.
+vimTwoletterEnterNormal(){
+  global vim
+  SendInput, {BackSpace 1}
+  Vim.State.SetNormal()
+}
+
 #If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimJJ"]["val"] == 1)
 ~j up:: ; jj: go to Normal mode.
   Input, jout, I T0.1 V L1, j
@@ -16,18 +24,4 @@ Return
     SendInput, {BackSpace 2}
     Vim.State.SetNormal()
   }
-Return
-
-#If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimJK"]["val"] == 1)
-j & k::
-k & j::
-  SendInput, {BackSpace 1}
-  Vim.State.SetNormal()
-Return
-
-#If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimSD"]["val"] == 1)
-s & d::
-d & s::
-  SendInput, {BackSpace 1}
-  Vim.State.SetNormal()
 Return

--- a/lib/util/vim_ahk_setting.ahk
+++ b/lib/util/vim_ahk_setting.ahk
@@ -4,3 +4,4 @@
                   ; Use ~500kB memory?
 #HotkeyInterval 2000 ; Hotkey interval (default 2000 milliseconds).
 #MaxHotkeysPerInterval 70 ; Max hotkeys per interval (default 50).
+; #warn

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -83,33 +83,34 @@ class VimAhk{
     GroupAdd, VimCursorSameAfterSelect, ahk_exe exproloer.exe ; Explorer
 
     ; Configuration values for Read/Write ini
-    this.Conf := {VimRestoreIME: {default: 1, val: 1
-        , description: "Restore IME status at entering Insert mode:"
-        , info: "Restore IME status at entering Insert mode."}
-      , VimJJ: {default: 0, val: 0
-        , description: "JJ enters Normal mode:"
-        , info: "Assign JJ enters Normal mode."}
-      , VimTwoLetterEsc: {default: "", val: ""
-        , description: "Two-letter insert-mode <esc> hotkey (sets normal mode)"
-        , info: "When these two letters are pressed together in insert mode, enters normal mode.`n`nSet one per line, exactly two letters per line.`nThe two letters must be different."}
-      , VimDisableUnused: {default: 1, val: 1
-        , description: "Disable unused keys in Normal mode:"
-        , info: "1: Do not disable unused keys`n2: Disable alphabets (+shift) and symbols`n3: Disable all including keys with modifiers (e.g. Ctrl+Z)"}
-      , VimSetTitleMatchMode: {default: "2", val: "2"
-        , description: "SetTitleMatchMode:"
-        , info: "[Mode] 1: Start with, 2: Contain, 3: Exact match.`n[Fast/Slow] Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow."}
-      , VimSetTitleMatchModeFS: {default: "Fast", val: "Fast"
-        , description: "SetTitleMatchMode"
-        , info: "[Mode]1: Start with, 2: Contain, 3: Exact match.`n[Fast/Slow]: Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow."}
-      , VimIconCheckInterval: {default: 1000, val: 1000
-        , description: "Icon check interval (ms):"
-        , info: "Interval to check vim_ahk status (ms) and change tray icon. If it is set to 0, the original AHK icon is set."}
-      , VimVerbose: {default: 1, val: 1
-        , description: "Verbose level:"
-        , info: "1: Nothing `n2: Minimum tooltip of status`n3: More info in tooltip`n4: Debug mode with a message box, which doesn't disappear automatically"}
-      , VimGroup: {default: this.Group, val: this.Group
-        , description: "Application:"
-        , info: "Set one application per line.`n`nIt can be any of Window Title, Class or Process.`nYou can check these values by Window Spy (in the right click menu of tray icon)."}}
+    this.Conf := {}
+    this.AddToConf("VimRestoreIME", 1, 1
+        , "Restore IME status at entering Insert mode:"
+        , "Restore IME status at entering Insert mode.")
+      this.AddToConf("VimJJ", 0, 0
+          , "JJ enters Normal mode:"
+        , "Assign JJ enters Normal mode.")
+      this.AddToConf("VimTwoLetterEsc", "", ""
+          , "Two-letter insert-mode <esc> hotkey (sets normal mode)"
+        , "When these two letters are pressed together in insert mode, enters normal mode.`n`nSet one per line, exactly two letters per line.`nThe two letters must be different.")
+      this.AddToConf("VimDisableUnused", 1, 1
+          , "Disable unused keys in Normal mode:"
+        , "1: Do not disable unused keys`n2: Disable alphabets (+shift) and symbols`n3: Disable all including keys with modifiers (e.g. Ctrl+Z)")
+      this.AddToConf("VimSetTitleMatchMode", "2", "2"
+          , "SetTitleMatchMode:"
+        , "[Mode] 1: Start with, 2: Contain, 3: Exact match.`n[Fast/Slow] Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow.")
+      this.AddToConf("VimSetTitleMatchModeFS", "Fast", "Fast"
+          , "SetTitleMatchMode"
+        , "[Mode]1: Start with, 2: Contain, 3: Exact match.`n[Fast/Slow]: Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow.")
+      this.AddToConf("VimIconCheckInterval", 1000, 1000
+          , "Icon check interval (ms):"
+        , "Interval to check vim_ahk status (ms) and change tray icon. If it is set to 0, the original AHK icon is set.")
+      this.AddToConf("VimVerbose", 1, 1
+          , "Verbose level:"
+        , "1: Nothing `n2: Minimum tooltip of status`n3: More info in tooltip`n4: Debug mode with a message box, which doesn't disappear automatically")
+      this.AddToConf("VimGroup", this.Group, this.Group
+          , "Application:"
+        , "Set one application per line.`n`nIt can be any of Window Title, Class or Process.`nYou can check these values by Window Spy (in the right click menu of tray icon).")
     this.CheckBoxes := ["VimRestoreIME", "VimJJ"]
 
     ; Other ToolTip Information
@@ -137,6 +138,10 @@ class VimAhk{
   SetInfo(variable, variablevaluename){
     key=%variable%%variablevaluename%
     this.Info[key] := this.Conf[variable]["info"]
+  }
+
+  AddToConf(setting, default_, val_, description_, info_){
+    this.Conf[setting] :=  {"default": default_, val: val_, description: description_, info: info_}
   }
 
   SetExistValue(){

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -47,21 +47,7 @@ class VimAhk{
     this.GroupN := 0
     this.GroupName := "VimGroup" . GroupN
 
-    ; Enable vim mode for following applications
-    this.Group :=                          "ahk_exe notepad.exe"   ; NotePad
-    this.Group := this.Group this.GroupDel "ahk_exe explorer.exe"  ; Explorer
-    this.Group := this.Group this.GroupDel "ahk_exe wordpad.exe"   ; WordPad
-    this.Group := this.Group this.GroupDel "ahk_exe TeraPad.exe"   ; TeraPad
-    this.Group := this.Group this.GroupDel "作成"                  ; Thunderbird, 日本語
-    this.Group := this.Group this.GroupDel "Write:"                ; Thuderbird, English
-    this.Group := this.Group this.GroupDel "ahk_exe POWERPNT.exe"  ; PowerPoint
-    this.Group := this.Group this.GroupDel "ahk_exe WINWORD.exe"   ; Word
-    this.Group := this.Group this.GroupDel "ahk_exe Evernote.exe"  ; Evernote
-    this.Group := this.Group this.GroupDel "ahk_exe Code.exe"      ; Visual Studio Code
-    this.Group := this.Group this.GroupDel "ahk_exe onenote.exe"   ; OneNote Desktop
-    this.Group := this.Group this.GroupDel "OneNote"               ; OneNote in Windows 10
-    this.Group := this.Group this.GroupDel "ahk_exe texworks.exe"  ; TexWork
-    this.Group := this.Group this.GroupDel "ahk_exe texstudio.exe" ; TexStudio
+    this.SetDefaultActiveWindows()
 
     ; Following application select the line break at Shift + End.
     GroupAdd, VimLBSelectGroup, ahk_exe POWERPNT.exe ; PowerPoint
@@ -80,7 +66,7 @@ class VimAhk{
     ; Followings start cursor from the same place after selection.
     ; Others start right/left (by cursor) point of the selection
     GroupAdd, VimCursorSameAfterSelect, ahk_exe notepad.exe ; NotePad
-    GroupAdd, VimCursorSameAfterSelect, ahk_exe exproloer.exe ; Explorer
+    GroupAdd, VimCursorSameAfterSelect, ahk_exe explorer.exe ; Explorer
 
     ; Configuration values for Read/Write ini
     this.Conf := {}
@@ -152,6 +138,10 @@ class VimAhk{
     }
   }
 
+  AddToActiveWindows(window){
+    this.Group := this.Group this.GroupDel window
+  }
+
   SetGroup(){
     this.GroupN++
     this.GroupName := "VimGroup" . this.GroupN
@@ -206,6 +196,28 @@ class VimAhk{
     this.Ini.ReadIni()
     this.VimMenu.SetMenu()
     this.Setup()
+  }
+
+  SetDefaultActiveWindows(){
+    ; Enable vim mode for following applications
+    defaults := ["ahk_exe texworks.exe"
+    , "ahk_exe texstudio.exe"
+    , "ahk_exe notepad.exe"
+    , "ahk_exe explorer.exe"
+    , "ahk_exe wordpad.exe"
+    , "ahk_exe TeraPad.exe"
+    , "ahk_exe POWERPNT.exe"
+    , "ahk_exe WINWORD.exe"
+    , "ahk_exe Evernote.exe"]
+
+    Loop % defaults.Length()
+        this.AddToActiveWindows(defaults[A_Index])
+
+    this.AddToActiveWindows("作成")                  ; Thunderbird, 日本語
+    this.AddToActiveWindows("Write:")                ; Thuderbird, English
+    this.AddToActiveWindows("ahk_exe Code.exe")      ; Visual Studio Code
+    this.AddToActiveWindows("ahk_exe onenote.exe")   ; OneNote Desktop
+    this.AddToActiveWindows("OneNote")               ; OneNote in Windows 10
   }
 }
 ; vim: sw=2:et:ts=2

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -17,9 +17,6 @@
 ; Key Bindings
 #Include %A_LineFile%\..\vim_bind.ahk
 
-twoLetterNormalMapsEnabled(){
-  return 0
-}
 class VimAhk{
   __About(){
     this.About.Version := "v0.6.0"

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -119,17 +119,12 @@ class VimAhk{
       textKey:=k . "Text"
       this.Info[textKey] := v["info"]
     }
-    this.Info["VimGroupList"] := this.Conf["VimGroup"]["info"]
-
-    this.Info["VimTwoLetterEscList"] := this.Conf["VimTwoLetterEsc"]["info"]
-
-    this.Info["VimDisableUnusedValue"] := this.Conf["VimDisableUnused"]["info"]
-
-    this.Info["VimSetTitleMatchModeValue"] := this.Conf["VimSetTitleMatchMode"]["info"]
-
-    this.Info["VimIconCheckIntervalEdit"] := this.Conf["VimIconCheckInterval"]["info"]
-
-    this.Info["VimVerboseValue"] := this.Conf["VimVerbose"]["info"]
+    this.SetInfo("VimGroup", "List")
+    this.SetInfo("VimTwoLetterEsc", "List")
+    this.SetInfo("VimDisableUnused", "Value")
+    this.SetInfo("VimSetTitleMatchMode", "Value")
+    this.SetInfo("VimIconCheckInterval", "Edit")
+    this.SetInfo("VimVerbose", "Value")
 
     this.Info["VimSettingOK"] := "Reflect changes and exit"
     this.Info["VimSettingReset"] := "Reset to the default values"
@@ -137,6 +132,11 @@ class VimAhk{
 
     ; Initialize
     this.Initialize()
+  }
+
+  SetInfo(variable, variablevaluename){
+    key=%variable%%variablevaluename%
+    this.Info[key] := this.Conf[variable]["info"]
   }
 
   SetExistValue(){

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -6,8 +6,8 @@
 
   MakeGui(){
     global VimRestoreIME, VimJJ, VimJK, VimSD
-    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList
-    global VimDisableUnusedText, VimSetTitleMatchModeText, VimIconCheckIntervalText, VimIconCheckIntervalEdit, VimVerboseText, VimGroupText, VimHomepage, VimSettingOK, VimSettingReset, VimSettingCancel
+    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterEscList
+    global VimDisableUnusedText, VimSetTitleMatchModeText, VimIconCheckIntervalText, VimIconCheckIntervalEdit, VimVerboseText, VimGroupText, VimHomepage, VimSettingOK, VimSettingReset, VimSettingCancel, VimTwoLetterEscText
     this.VimVal2V()
     Gui, % this.Hwnd ":-MinimizeBox"
     Gui, % this.Hwnd ":-Resize"
@@ -24,6 +24,8 @@
       created  := 1
       GuiControl, % this.Hwnd ":", % k, % %k%
     }
+    Gui, % this.Hwnd ":Add", Text, % "XM+10 Y+5 g" this.__Class ".TwoLetterEscText vVimTwoLetterEscText", % this.Vim.Conf["VimTwoLetterEsc"]["description"]
+    Gui, % this.Hwnd ":Add", Edit, XM+10 Y+5 R4 W100 Multi vVimTwoLetterEscList, % VimTwoLetterEscList
     Gui, % this.Hwnd ":Add", Text, % "XM+10 Y+15 g" this.__Class ".DisableUnusedText vVimDisableUnusedText", % this.Vim.Conf["VimDisableUnused"]["description"]
     Gui, % this.Hwnd ":Add", DropDownList, % "+HwndHwndDisableUnused X+5 Y+-16 W30 vVimDisableUnused Choose" VimDisableUnused, 1|2|3
     this.HwndAll.Push(HwndDisableUnused)
@@ -85,10 +87,11 @@
 
   UpdateGuiValue(){
     global VimRestoreIME, VimJJ, VimJK, VimSD
-    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList
+    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterEsc, VimTwoLetterEscList
     for i, k in this.Vim.Checkboxes {
       GuiControl, % this.Hwnd ":", % k, % %k%
     }
+    GuiControl, % this.Hwnd ":", VimTwoLetterEscList, % VimTwoLetterEscList
     GuiControl, % this.Hwnd ":Choose", VimDisableUnused, % VimDisableUnused
     GuiControl, % this.Hwnd ":", VimIconCheckInterval, % VimIconCheckInterval
     if(VimSetTitleMatchMode == "RegEx"){
@@ -111,6 +114,9 @@
   DisableUnusedText(){
   }
 
+  TwoLetterEscText(){
+  }
+
   SetTitleMatchModeText(){
   }
 
@@ -123,31 +129,40 @@
   GroupText(){
   }
 
+  ; Converts variable to config text/entry?
   VimV2Conf(){
     global VimRestoreIME, VimJJ, VimJK, VimSD
-    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList
-    VimGroup := ""
-    tmpArray := []
-    Loop, Parse, VimGroupList, `n
-    {
-      if(! tmpArray.Haskey(A_LoopField)){
-        tmpArray.push(A_LoopField)
-        if(VimGroup == ""){
-          VimGroup := A_LoopField
-        }else{
-          VimGroup := VimGroup . this.Vim.GroupDel . A_LoopField
-        }
-      }
-    }
+    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterEsc, VimTwoLetterEscList
+    VimGroup := this.VimParseList(VimGroupList)
+    VimTwoLetterEsc := this.VimParseList(VimTwoLetterEscList)
     for k, v in this.Vim.Conf {
       v["val"] := %k%
     }
   }
 
+  VimParseList(list){
+    result := ""
+    tmpArray := []
+    Loop, Parse, list, `n
+    {
+      if(! tmpArray.Haskey(A_LoopField)){
+        tmpArray.push(A_LoopField)
+        if(result == ""){
+          result := A_LoopField
+        }else{
+          result := result . this.Vim.GroupDel . A_LoopField
+        }
+      }
+    }
+    return result
+  }
+
+  ; Converts config elements to a variable?
   VimConf2V(vd){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
-    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList
+    global VimRestoreIME, VimJJ
+    global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterEscList
     StringReplace, VimGroupList, % this.Vim.Conf["VimGroup"][vd], % this.Vim.GroupDel, `n, All
+    StringReplace, VimTwoLetterEscList, % this.Vim.Conf["VimTwoLetterEsc"][vd], % this.Vim.GroupDel, `n, All
     for k, v in this.Vim.Conf {
       %k% := v[vd]
     }

--- a/lib/vim_state.ahk
+++ b/lib/vim_state.ahk
@@ -97,7 +97,7 @@
       Return
     }
     try{
-      InOrBlank:= (not full_match) ? "in " : ""
+      InOrBlank:= (not FullMatch) ? "in " : ""
       if not this.HasValue(this.PossibleVimModes, Mode, FullMatch){
         throw Exception("Invalid mode specified",-2,
         (Join


### PR DESCRIPTION
Adds a list option to dynamically create hotkey pairs like j & k,
allowing users to set an arbitrary combination (like kv, fd, etc).

Doesn't touch jj. Does remove SD and JK settings, which may need a deprecation warning if you care about changing settings.

Also includes some refactoring. You may want me to revert 
a5b2323, but I think it's less likely to lead to errors due to typos (at the expense of being slightly harder to read, but I think that could also still be fixed if you wanted it)