### PR TITLE
Deprecate VimSD, VimJK settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ vim_ahk also works on other applications which use these Class/Process name (mos
 |:-----|:----------|:------|
 |VimRestoreIME|If 1, IME status is restored at entering insert mode.|1|
 |VimJJ|If 1, `jj` changes mode to Normal from Insert.|0|
-|VimJK|If 1, `jk` changes mode to Normal from Insert.|0|
-|VimSD|If 1, `sd` changes mode to Normal from Insert.|0|
-|VimTwoLetterEsc|A list of character pairs to press together during insert mode to get to normal mode. For example, a value of `jf` means pressing `j` and `f` at the same time will enter normal mode. (`jk` and `sd` can be enabled with above options, too.)||
+|VimTwoLetterEsc|A list of character pairs to press together during insert mode to get to normal mode. For example, a value of `jf` means pressing `j` and `f` at the same time will enter normal mode.||
 |VimDisableUnused|Disable level of unused keys in Normal mode (see below for details).|3|
 |VimSetTitleMatchMode|SetTitleMatchMode: 1: Start with, 2: Contain, 3: Exact match|2|
 |VimSetTitleMatchModeFS|SetTitleMatchMode: Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow|Fast|
@@ -153,15 +151,11 @@ After pressing `:`, a few commands to save/quit are available.
 |:----------:|:-------|
 |ESC/Ctrl-[| Enter Normal Mode. Holding (0.5s) these keys emulate normal ESC.|
 |jj|Enter Normal Mode, if enabled.|
-|jk|Enter Normal Mode, if enabled.|
-|sd|Enter Normal Mode, if enabled.|
 |Custom two letters|If two-letter mapping is set.|
 
 ESC/Ctrl-[ switch off IME if IME is on.
 ESC acts as ESC when IME is on and converting instructions.
 Ctrl-[ switches off IME and enters Normal Mode even if IME is on.
-
-jj, jk or sd is optional one, which is enabled when VimJJ/VimJK/VimSK = 1, respectively.
 
 If using a custom two-letter hotkey to enter normal mode, the two letters must be different.
 

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -17,17 +17,3 @@ Return
     Vim.State.SetNormal()
   }
 Return
-
-#If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimJK"]["val"] == 1)
-j & k::
-k & j::
-  SendInput, {BackSpace 1}
-  Vim.State.SetNormal()
-Return
-
-#If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimSD"]["val"] == 1)
-s & d::
-d & s::
-  SendInput, {BackSpace 1}
-  Vim.State.SetNormal()
-Return

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -73,12 +73,6 @@ class VimAhk{
     this.AddToConf("VimJJ", 0, 0
       , "JJ enters Normal mode:"
       , "Assign JJ enters Normal mode.")
-    this.AddToConf("VimJK", 0, 0
-      , "JK enters Normal mode:"
-      , "Assign JK enters Normal mode.")
-    this.AddToConf("VimSD", 0, 0
-      , "SD enters Normal mode:"
-      , "Assign SD enters Normal mode.")
     this.AddToConf("VimTwoLetter", "", ""
       , "Two-letter insert mode <esc> hotkey (sets normal mode)"
       , "When these two letters are pressed together in insert mode, enters normal mode.`n`nSet one per line, exactly two letters per line.`nThe two letters must be different.")
@@ -100,7 +94,7 @@ class VimAhk{
     this.AddToConf("VimGroup", DefaultGroup, DefaultGroup
       , "Application:"
       , "Set one application per line.`n`nIt can be any of Window Title, Class or Process.`nYou can check these values by Window Spy (in the right click menu of tray icon).")
-    this.CheckBoxes := ["VimRestoreIME", "VimJJ", "VimJK", "VimSD"]
+    this.CheckBoxes := ["VimRestoreIME", "VimJJ"]
 
     ; Other ToolTip Information
     this.Info := {}

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -232,9 +232,11 @@ class VimAhk{
     this.Ini.ReadIni(DeprecatedSettingsMap)
     if (DeprecatedSettingsMap["VimSD"]["val"] = 1){
       this.AddToTwoLetterMap("s","d")
+      this.Ini.DeleteIniValue("VimSD")
     }
     if (DeprecatedSettingsMap["VimJK"]["val"] = 1){
       this.AddToTwoLetterMap("j","k")
+      this.Ini.DeleteIniValue("VimJK")
     }
   }
   HasValue(haystack, needle){

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -241,7 +241,7 @@ class VimAhk{
     return this.vim.store.HasValue(haystack, needle)
   }
   AddToTwoLetterMap(l1, l2){
-    return
+    this.Conf["VimTwoLetter"]["val"] := this.Conf["VimTwoLetter"]["val"] . this.GroupDel . l1 . l2
   }
 
 }

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -26,6 +26,7 @@ class VimAhk{
     this.About.Homepage := "https://github.com/rcmdnk/vim_ahk"
     this.Info["VimHomepage"] := this.About.Homepage
   }
+  DeprecatedSettings := ["VimSD", "VimJK"]
 
   __New(setup=true){
     ; Classes
@@ -188,6 +189,7 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
+    this.ReadDeprecatedSettings()
     this.VimMenu.SetMenu()
     this.Setup()
   }
@@ -219,4 +221,27 @@ class VimAhk{
     }
     Return DefaultGroup
   }
+
+  ReadDeprecatedSettings(){
+    DeprecatedSettingsMap := {}
+    ; loop % this.DeprecatedSettings.length()
+    for index, setting in this.DeprecatedSettings
+    {
+      DeprecatedSettingsMap[setting] := {"default": "", "val": "", "description": "", "info": ""}
+    }
+    this.Ini.ReadIni(DeprecatedSettingsMap)
+    if (DeprecatedSettingsMap["VimSD"]["val"] = 1){
+      this.AddToTwoLetterMap("s","d")
+    }
+    if (DeprecatedSettingsMap["VimJK"]["val"] = 1){
+      this.AddToTwoLetterMap("j","k")
+    }
+  }
+  HasValue(haystack, needle){
+    return this.vim.store.HasValue(haystack, needle)
+  }
+  AddToTwoLetterMap(l1, l2){
+    return
+  }
+
 }

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -40,8 +40,15 @@
     return out
   }
 
-  DeleteIniValue(key, file=this.Ini, section_=this.Section){
-    IniDelete, file, section_, key
+  DeleteIniValue(key, file="", section_=""){
+    if (file = "")
+      file := this.Ini
+    if (section_ = "")
+      section_ := this.Section
+    this.RemoveIniValue(file, section_, key)
+  }
+  RemoveIniValue(file, iniSection, key){
+    IniDelete, % file, % iniSection, % key
   }
 
   WriteIni(){

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -19,8 +19,11 @@
     this.section := section
   }
 
-  ReadIni(){
-    for k, v in this.Vim.Conf {
+  ReadIni(store=""){
+    if (store = ""){
+        store := this.Vim.Conf
+    }
+    for k, v in store {
       current := v["val"]
       if(current != ""){
         IniRead, val, % this.Ini, % this.Section, % k, % current

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -40,6 +40,10 @@
     return out
   }
 
+  DeleteIniValue(key, file=this.Ini, section_=this.Section){
+    IniDelete, file, section_, key
+  }
+
   WriteIni(){
     IfNotExist, % this.IniDir
       FileCreateDir, this.IniDir

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -26,13 +26,18 @@
     for k, v in store {
       current := v["val"]
       if(current != ""){
-        IniRead, val, % this.Ini, % this.Section, % k, % current
+        val := this.ReadIniValue(this.Ini, this.Section, k, current)
       }else{
-        IniRead, val, % this.Ini, % this.Section, % k, %A_Space%
+        val := this.ReadIniValue(this.Ini, this.Section, k, A_Space)
       }
       %k% := val
       v["val"] := val
     }
+  }
+
+  ReadIniValue(file, iniSection, key, default_=""){
+    IniRead, out, % file, % iniSection, % key, % default_
+    return out
   }
 
   WriteIni(){

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -19,11 +19,11 @@
     this.section := section
   }
 
-  ReadIni(store=""){
-    if (store = ""){
-        store := this.Vim.Conf
+  ReadIni(SettingsStore=""){
+    if (SettingsStore = ""){
+        SettingsStore := this.Vim.Conf
     }
-    for k, v in store {
+    for k, v in SettingsStore {
       current := v["val"]
       if(current != ""){
         val := this.ReadIniValue(this.Ini, this.Section, k, current)

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -5,7 +5,7 @@
   }
 
   MakeGui(){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     global VimDisableUnusedText, VimSetTitleMatchModeText, VimIconCheckIntervalText, VimIconCheckIntervalEdit, VimVerboseText, VimGroupText, VimHomepage, VimSettingOK, VimSettingReset, VimSettingCancel, VimTwoLetterText
     this.VimVal2V()
@@ -86,7 +86,7 @@
   }
 
   UpdateGuiValue(){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     for i, k in this.Vim.Checkboxes {
       GuiControl, % this.Hwnd ":", % k, % %k%
@@ -130,7 +130,7 @@
   }
 
   VimV2Conf(){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     VimGroup := this.VimParseList(VimGroupList)
     VimTwoLetter := this.VimParseList(VimTwoLetterList)
@@ -157,7 +157,7 @@
   }
 
   VimConf2V(vd){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     StringReplace, VimGroupList, % this.Vim.Conf["VimGroup"][vd], % this.Vim.GroupDel, `n, All
     StringReplace, VimTwoLetterList, % this.Vim.Conf["VimTwoLetter"][vd], % this.Vim.GroupDel, `n, All


### PR DESCRIPTION
If these settings are present and enabled in the ini, converts them to TwoLetterMaps. Still has one step to go, which is removing the setting from the ini. (Otherwise, removing the map from twolettermaps will not last across restarts, because the old setting will be re-read.)