### PR TITLE
Add option to swap behavior of held and tapped esc key

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ vim_ahk also works on other applications which use these Class/Process name (mos
 |:-----|:----------|:------|
 |VimRestoreIME|If 1, IME status is restored at entering insert mode.|1|
 |VimJJ|If 1, `jj` changes mode to Normal from Insert.|0|
-|VimJK|If 1, `jk` changes mode to Normal from Insert.|0|
-|VimSD|If 1, `sd` changes mode to Normal from Insert.|0|
-|VimTwoLetterEsc|A list of character pairs to press together during insert mode to get to normal mode. For example, a value of `jf` means pressing `j` and `f` at the same time will enter normal mode. (`jk` and `sd` can be enabled with above options, too.)||
+|VimTwoLetterEsc|A list of character pairs to press together during insert mode to get to normal mode. For example, a value of `jf` means pressing `j` and `f` at the same time will enter normal mode.||
 |VimDisableUnused|Disable level of unused keys in Normal mode (see below for details).|3|
 |VimSetTitleMatchMode|SetTitleMatchMode: 1: Start with, 2: Contain, 3: Exact match|2|
 |VimSetTitleMatchModeFS|SetTitleMatchMode: Fast: Text is not detected for such edit control, Slow: Works for all windows, but slow|Fast|
@@ -153,15 +151,11 @@ After pressing `:`, a few commands to save/quit are available.
 |:----------:|:-------|
 |ESC/Ctrl-[| Enter Normal Mode. Holding (0.5s) these keys emulate normal ESC.|
 |jj|Enter Normal Mode, if enabled.|
-|jk|Enter Normal Mode, if enabled.|
-|sd|Enter Normal Mode, if enabled.|
 |Custom two letters|If two-letter mapping is set.|
 
 ESC/Ctrl-[ switch off IME if IME is on.
 ESC acts as ESC when IME is on and converting instructions.
 Ctrl-[ switches off IME and enters Normal Mode even if IME is on.
-
-jj, jk or sd is optional one, which is enabled when VimJJ/VimJK/VimSK = 1, respectively.
 
 If using a custom two-letter hotkey to enter normal mode, the two letters must be different.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ vim_ahk also works on other applications which use these Class/Process name (mos
 |:-----|:----------|:------|
 |VimRestoreIME|If 1, IME status is restored at entering insert mode.|1|
 |VimJJ|If 1, `jj` changes mode to Normal from Insert.|0|
+|VimLongEscNormal|If 1, pushing escape sends escape to the underlying application, while holding escape sets normal mode.|0|
 |VimTwoLetterEsc|A list of character pairs to press together during insert mode to get to normal mode. For example, a value of `jf` means pressing `j` and `f` at the same time will enter normal mode.||
 |VimDisableUnused|Disable level of unused keys in Normal mode (see below for details).|3|
 |VimSetTitleMatchMode|SetTitleMatchMode: 1: Start with, 2: Contain, 3: Exact match|2|

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -4,23 +4,12 @@ Esc::VimHandleEsc()  ; Just send Esc at converting, long press for normal Esc.
 VimHandleEsc(){
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel
-  if(LongPress){
-    VimEscLongPress()
-  }else{
-    VimEsc()
-  }
-}
-VimEscLongPress(){
   global Vim, VimLongEscNormal
-  if (VimLongEscNormal){
-    Vim.State.SetNormal()
-  }else{
-    Send,{Esc}
+  SetNormal := VimLongEscNormal
+  if (!LongPress){
+    SetNormal := !SetNormal
   }
-}
-VimEsc(){
-  global Vim, VimLongEscNormal
-  if (!VimLongEscNormal){
+  if (SetNormal){
     Vim.State.SetNormal()
   }else{
     Send,{Esc}

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -1,13 +1,31 @@
 ﻿#If WinActive("ahk_group " . Vim.GroupName)
-Esc:: ; Just send Esc at converting, long press for normal Esc.
-^[:: ; Go to Normal mode (for vim) with IME off even at converting.
+Esc::VimHandleEsc()  ; Just send Esc at converting, long press for normal Esc.
+^[::VimHandleEsc()  ; Go to Normal mode (for vim) with IME off even at converting.
+VimHandleEsc(){
   KeyWait, Esc, T0.5
-  if(ErrorLevel){ ; long press to Esc
-    Send,{Esc}
-    Return
+  LongPress := ErrorLevel
+  if(LongPress){
+    VimEscLongPress()
+  }else{
+    VimEsc()
   }
-  Vim.State.SetNormal()
-Return
+}
+VimEscLongPress(){
+  global Vim, VimLongEscNormal
+  if (VimLongEscNormal){
+    Vim.State.SetNormal()
+  }else{
+    Send,{Esc}
+  }
+}
+VimEsc(){
+  global Vim, VimLongEscNormal
+  if (!VimLongEscNormal){
+    Vim.State.SetNormal()
+  }else{
+    Send,{Esc}
+  }
+}
 
 #If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimJJ"]["val"] == 1)
 ~j up:: ; jj: go to Normal mode.

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -7,8 +7,9 @@ VimHandleEsc(){
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel
   global Vim, VimLongEscNormal
-  ; Both or neither option
-  SetNormal := (VimLongEscNormal && LongPress) || !(VimLongEscNormal || LongPress)
+  both := VimLongEscNormal && LongPress
+  neither := !(VimLongEscNormal || LongPress)
+  SetNormal :=  both or neither
   if (SetNormal) {
       Vim.State.SetNormal()
   } else {

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -6,10 +6,6 @@ VimHandleEsc(){
   ; within the time limit, sets errorlevel to 1.
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel
-  if (LongPress){
-    ; Have to ensure the key has been released.
-    KeyWait, Esc
-  }
   global Vim, VimLongEscNormal
   SetNormal := VimLongEscNormal
   if (VimLongEscNormal) {
@@ -24,6 +20,11 @@ VimHandleEsc(){
     }else{
       Vim.State.SetNormal()
     }
+  }
+  if (LongPress){
+    ; Have to ensure the key has been released, otherwise this will get
+    ; triggered again.
+    KeyWait, Esc
   }
 }
 

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -1,6 +1,6 @@
 ﻿#If WinActive("ahk_group " . Vim.GroupName)
 Esc::VimHandleEsc()  ; Just send Esc at converting, long press for normal Esc.
-^[::VimHandleEsc()  ; Go to Normal mode (for vim) with IME off even at converting.
+^[::Vim.State.SetNormal()
 VimHandleEsc(){
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -1,18 +1,29 @@
 ﻿#If WinActive("ahk_group " . Vim.GroupName)
-Esc::VimHandleEsc()  ; Just send Esc at converting, long press for normal Esc.
+Esc::VimHandleEsc()
 ^[::Vim.State.SetNormal()
 VimHandleEsc(){
+  ; The keywait waits for esc to be released. If it doesn't detect a release
+  ; within the time limit, sets errorlevel to 1.
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel
+  if (LongPress){
+    ; Have to ensure the key has been released.
+    KeyWait, Esc
+  }
   global Vim, VimLongEscNormal
   SetNormal := VimLongEscNormal
-  if (!LongPress){
-    SetNormal := !SetNormal
-  }
-  if (SetNormal){
-    Vim.State.SetNormal()
-  }else{
-    Send,{Esc}
+  if (VimLongEscNormal) {
+    if (LongPress){
+      Vim.State.SetNormal()
+    } else {
+      Send,{Esc}
+    }
+  } else {
+    if (LongPress){
+      Send,{Esc}
+    }else{
+      Vim.State.SetNormal()
+    }
   }
 }
 

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -17,17 +17,3 @@ Return
     Vim.State.SetNormal()
   }
 Return
-
-#If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimJK"]["val"] == 1)
-j & k::
-k & j::
-  SendInput, {BackSpace 1}
-  Vim.State.SetNormal()
-Return
-
-#If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Insert")) and (Vim.Conf["VimSD"]["val"] == 1)
-s & d::
-d & s::
-  SendInput, {BackSpace 1}
-  Vim.State.SetNormal()
-Return

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -7,7 +7,8 @@ VimHandleEsc(){
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel
   global Vim, VimLongEscNormal
-  SetNormal := (VimLongEscNormal && LongPress) || (!VimLongEscNormal && !LongPress)
+  ; Both or neither option
+  SetNormal := (VimLongEscNormal && LongPress) || !(VimLongEscNormal || LongPress)
   if (SetNormal) {
       Vim.State.SetNormal()
   } else {

--- a/lib/bind/vim_enter_normal.ahk
+++ b/lib/bind/vim_enter_normal.ahk
@@ -7,19 +7,11 @@ VimHandleEsc(){
   KeyWait, Esc, T0.5
   LongPress := ErrorLevel
   global Vim, VimLongEscNormal
-  SetNormal := VimLongEscNormal
-  if (VimLongEscNormal) {
-    if (LongPress){
+  SetNormal := (VimLongEscNormal && LongPress) || (!VimLongEscNormal && !LongPress)
+  if (SetNormal) {
       Vim.State.SetNormal()
-    } else {
-      Send,{Esc}
-    }
   } else {
-    if (LongPress){
       Send,{Esc}
-    }else{
-      Vim.State.SetNormal()
-    }
   }
   if (LongPress){
     ; Have to ensure the key has been released, otherwise this will get

--- a/lib/bind/vim_visual.ahk
+++ b/lib/bind/vim_visual.ahk
@@ -11,8 +11,10 @@ Return
   Send, {Home}+{Down}
 Return
 
-; ydc
 #If WinActive("ahk_group " . Vim.GroupName) and (Vim.State.StrIsInCurrentVimMode( "Visual"))
+v::Vim.State.SetMode("Vim_Normal")
+
+; ydc
 y::
   Clipboard :=
   Send, ^c

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -71,6 +71,9 @@ class VimAhk{
     this.AddToConf("VimRestoreIME", 1, 1
       , "Restore IME status at entering insert mode:"
       , "Restore IME status at entering insert mode.")
+    this.AddToConf("VimLongEscNormal", 0, 0
+      , "Long press esc to enter normal mode:"
+      , "Hold esc to enter normal, allowing single press to send esc to window")
     this.AddToConf("VimJJ", 0, 0
       , "JJ enters Normal mode:"
       , "Assign JJ enters Normal mode.")
@@ -95,7 +98,8 @@ class VimAhk{
     this.AddToConf("VimGroup", DefaultGroup, DefaultGroup
       , "Application:"
       , "Set one application per line.`n`nIt can be any of Window Title, Class or Process.`nYou can check these values by Window Spy (in the right click menu of tray icon).")
-    this.CheckBoxes := ["VimRestoreIME", "VimJJ"]
+
+    this.CheckBoxes := ["VimRestoreIME", "VimJJ", "VimLongEscNormal"]
 
     ; Other ToolTip Information
     this.Info := {}

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -73,12 +73,6 @@ class VimAhk{
     this.AddToConf("VimJJ", 0, 0
       , "JJ enters Normal mode:"
       , "Assign JJ enters Normal mode.")
-    this.AddToConf("VimJK", 0, 0
-      , "JK enters Normal mode:"
-      , "Assign JK enters Normal mode.")
-    this.AddToConf("VimSD", 0, 0
-      , "SD enters Normal mode:"
-      , "Assign SD enters Normal mode.")
     this.AddToConf("VimTwoLetter", "", ""
       , "Two-letter insert mode <esc> hotkey (sets normal mode)"
       , "When these two letters are pressed together in insert mode, enters normal mode.`n`nSet one per line, exactly two letters per line.`nThe two letters must be different.")
@@ -100,7 +94,7 @@ class VimAhk{
     this.AddToConf("VimGroup", DefaultGroup, DefaultGroup
       , "Application:"
       , "Set one application per line.`n`nIt can be any of Window Title, Class or Process.`nYou can check these values by Window Spy (in the right click menu of tray icon).")
-    this.CheckBoxes := ["VimRestoreIME", "VimJJ", "VimJK", "VimSD"]
+    this.CheckBoxes := ["VimRestoreIME", "VimJJ"]
 
     ; Other ToolTip Information
     this.Info := {}

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -232,9 +232,11 @@ class VimAhk{
     this.Ini.ReadIni(DeprecatedSettingsMap)
     if (DeprecatedSettingsMap["VimSD"]["val"] = 1){
       this.AddToTwoLetterMap("s","d")
+      this.Ini.DeleteIniValue("VimSD")
     }
     if (DeprecatedSettingsMap["VimJK"]["val"] = 1){
       this.AddToTwoLetterMap("j","k")
+      this.Ini.DeleteIniValue("VimJK")
     }
   }
   HasValue(haystack, needle){

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -241,7 +241,7 @@ class VimAhk{
     return this.vim.store.HasValue(haystack, needle)
   }
   AddToTwoLetterMap(l1, l2){
-    return
+    this.Conf["VimTwoLetter"]["val"] := this.Conf["VimTwoLetter"]["val"] . this.GroupDel . l1 . l2
   }
 
 }

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -26,6 +26,7 @@ class VimAhk{
     this.About.Homepage := "https://github.com/rcmdnk/vim_ahk"
     this.Info["VimHomepage"] := this.About.Homepage
   }
+  DeprecatedSettings := ["VimSD", "VimJK"]
 
   __New(setup=true){
     ; Classes
@@ -188,6 +189,7 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
+    this.ReadDeprecatedSettings()
     this.VimMenu.SetMenu()
     this.Setup()
   }
@@ -219,4 +221,27 @@ class VimAhk{
     }
     Return DefaultGroup
   }
+
+  ReadDeprecatedSettings(){
+    DeprecatedSettingsMap := {}
+    ; loop % this.DeprecatedSettings.length()
+    for index, setting in this.DeprecatedSettings
+    {
+      DeprecatedSettingsMap[setting] := {"default": "", "val": "", "description": "", "info": ""}
+    }
+    this.Ini.ReadIni(DeprecatedSettingsMap)
+    if (DeprecatedSettingsMap["VimSD"]["val"] = 1){
+      this.AddToTwoLetterMap("s","d")
+    }
+    if (DeprecatedSettingsMap["VimJK"]["val"] = 1){
+      this.AddToTwoLetterMap("j","k")
+    }
+  }
+  HasValue(haystack, needle){
+    return this.vim.store.HasValue(haystack, needle)
+  }
+  AddToTwoLetterMap(l1, l2){
+    return
+  }
+
 }

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -40,8 +40,15 @@
     return out
   }
 
-  DeleteIniValue(key, file=this.Ini, section_=this.Section){
-    IniDelete, file, section_, key
+  DeleteIniValue(key, file="", section_=""){
+    if (file = "")
+      file := this.Ini
+    if (section_ = "")
+      section_ := this.Section
+    this.RemoveIniValue(file, section_, key)
+  }
+  RemoveIniValue(file, iniSection, key){
+    IniDelete, % file, % iniSection, % key
   }
 
   WriteIni(){

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -19,8 +19,11 @@
     this.section := section
   }
 
-  ReadIni(){
-    for k, v in this.Vim.Conf {
+  ReadIni(store=""){
+    if (store = ""){
+        store := this.Vim.Conf
+    }
+    for k, v in store {
       current := v["val"]
       if(current != ""){
         IniRead, val, % this.Ini, % this.Section, % k, % current

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -40,6 +40,10 @@
     return out
   }
 
+  DeleteIniValue(key, file=this.Ini, section_=this.Section){
+    IniDelete, file, section_, key
+  }
+
   WriteIni(){
     IfNotExist, % this.IniDir
       FileCreateDir, this.IniDir

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -26,13 +26,18 @@
     for k, v in store {
       current := v["val"]
       if(current != ""){
-        IniRead, val, % this.Ini, % this.Section, % k, % current
+        val := this.ReadIniValue(this.Ini, this.Section, k, current)
       }else{
-        IniRead, val, % this.Ini, % this.Section, % k, %A_Space%
+        val := this.ReadIniValue(this.Ini, this.Section, k, A_Space)
       }
       %k% := val
       v["val"] := val
     }
+  }
+
+  ReadIniValue(file, iniSection, key, default_=""){
+    IniRead, out, % file, % iniSection, % key, % default_
+    return out
   }
 
   WriteIni(){

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -19,11 +19,11 @@
     this.section := section
   }
 
-  ReadIni(store=""){
-    if (store = ""){
-        store := this.Vim.Conf
+  ReadIni(SettingsStore=""){
+    if (SettingsStore = ""){
+        SettingsStore := this.Vim.Conf
     }
-    for k, v in store {
+    for k, v in SettingsStore {
       current := v["val"]
       if(current != ""){
         val := this.ReadIniValue(this.Ini, this.Section, k, current)

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -80,18 +80,9 @@
 
     ; 1 character
     if(key == "j"){
-      ; Only for OneNote of less than windows 10?
-      if WinActive("ahk_group VimOneNoteGroup"){
-        Send ^{Down}
-      } else {
-        Send,{Down}
-      }
+      this.SendDown()
     }else if(key="k"){
-      if WinActive("ahk_group VimOneNoteGroup"){
-        Send ^{Up}
-      }else{
-        Send,{Up}
-      }
+      this.SendUp()
     ; Page Up/Down
     }else if(key == "^u"){
       Send, {Up 10}
@@ -137,4 +128,23 @@
       this.Vim.Move.Move(key)
     }
   }
+
+  SendUp(){
+    ; Only for OneNote of less than windows 10?
+    if WinActive("ahk_group VimOneNoteGroup"){
+      Send ^{Up}
+    } else {
+      Send,{Up}
+    }
+  }
+
+  SendDown(){
+    ; Only for OneNote of less than windows 10?
+    if WinActive("ahk_group VimOneNoteGroup"){
+      Send ^{Down}
+    } else {
+      Send,{Down}
+    }
+  }
+
 }

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -132,7 +132,7 @@
   SendUp(){
     ; Only for OneNote of less than windows 10?
     if WinActive("ahk_group VimOneNoteGroup"){
-      Send ^{Up}
+      run, %A_scriptdir%\lib\util\sendUp.exe
     } else {
       Send,{Up}
     }
@@ -141,7 +141,7 @@
   SendDown(){
     ; Only for OneNote of less than windows 10?
     if WinActive("ahk_group VimOneNoteGroup"){
-      Send ^{Down}
+      run, %A_scriptdir%\lib\util\sendDown.exe
     } else {
       Send,{Down}
     }

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -126,6 +126,7 @@
       this.Vim.State.SetMode("Insert")
     }
     this.Vim.State.SetMode("", 0, 0)
+    send {ctrl up}
   }
 
   Repeat(key=""){

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -5,7 +5,7 @@
   }
 
   MakeGui(){
-    global VimRestoreIME, VimJJ
+    global VimRestoreIME, VimJJ, VimLongEscNormal
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     global VimDisableUnusedText, VimSetTitleMatchModeText, VimIconCheckIntervalText, VimIconCheckIntervalEdit, VimVerboseText, VimGroupText, VimHomepage, VimSettingOK, VimSettingReset, VimSettingCancel, VimTwoLetterText
     this.VimVal2V()
@@ -86,7 +86,7 @@
   }
 
   UpdateGuiValue(){
-    global VimRestoreIME, VimJJ
+    global VimRestoreIME, VimJJ, VimLongEscNormal
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     for i, k in this.Vim.Checkboxes {
       GuiControl, % this.Hwnd ":", % k, % %k%
@@ -130,7 +130,7 @@
   }
 
   VimV2Conf(){
-    global VimRestoreIME, VimJJ
+    global VimRestoreIME, VimJJ, VimLongEscNormal
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     VimGroup := this.VimParseList(VimGroupList)
     VimTwoLetter := this.VimParseList(VimTwoLetterList)
@@ -157,7 +157,7 @@
   }
 
   VimConf2V(vd){
-    global VimRestoreIME, VimJJ
+    global VimRestoreIME, VimJJ, VimLongEscNormal
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     StringReplace, VimGroupList, % this.Vim.Conf["VimGroup"][vd], % this.Vim.GroupDel, `n, All
     StringReplace, VimTwoLetterList, % this.Vim.Conf["VimTwoLetter"][vd], % this.Vim.GroupDel, `n, All

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -5,7 +5,7 @@
   }
 
   MakeGui(){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     global VimDisableUnusedText, VimSetTitleMatchModeText, VimIconCheckIntervalText, VimIconCheckIntervalEdit, VimVerboseText, VimGroupText, VimHomepage, VimSettingOK, VimSettingReset, VimSettingCancel, VimTwoLetterText
     this.VimVal2V()
@@ -86,7 +86,7 @@
   }
 
   UpdateGuiValue(){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     for i, k in this.Vim.Checkboxes {
       GuiControl, % this.Hwnd ":", % k, % %k%
@@ -130,7 +130,7 @@
   }
 
   VimV2Conf(){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     VimGroup := this.VimParseList(VimGroupList)
     VimTwoLetter := this.VimParseList(VimTwoLetterList)
@@ -157,7 +157,7 @@
   }
 
   VimConf2V(vd){
-    global VimRestoreIME, VimJJ, VimJK, VimSD
+    global VimRestoreIME, VimJJ
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     StringReplace, VimGroupList, % this.Vim.Conf["VimGroup"][vd], % this.Vim.GroupDel, `n, All
     StringReplace, VimTwoLetterList, % this.Vim.Conf["VimTwoLetter"][vd], % this.Vim.GroupDel, `n, All


### PR DESCRIPTION
This is useful if you use non-esc methods to enter normal (eg `^[`, jj etc), and type in applications where the escape key is useful.

This is branched off my other PRs, to make it easier to merge once they have been merged.