### PR TITLE
Fix O for onenote or first line of file

### DIFF
--- a/lib/bind/vim_enter_insert.ahk
+++ b/lib/bind/vim_enter_insert.ahk
@@ -22,6 +22,6 @@ o::
 Return
 
 +o::
-  Send, {Up}{End}{Enter}
+  Send, {Home}{Enter}{Left}
   Vim.State.SetMode("Insert")
 Return


### PR DESCRIPTION
Previous sequence for mimicking vim `O` would not work on the first line
of a file, and would not work in onenote (where up doesn't work)
