### PR TITLE
fixed "k" in Normal-Mode

### DIFF
--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -89,7 +89,7 @@
       if WinActive("ahk_group VimOneNoteGroup"){
         Send ^{Up}
       } else {
-        Send,Up}
+        Send,{Up}
       }
     ; Page Up/Down
     }else if(key == "^u"){


### PR DESCRIPTION
"{" was missing
pressing "k" was writing "Up" into my Word-Document

don't know if this is enough for a pull request it's my first