### PR TITLE
Add option to thicken text caret when in normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ All of these can be changed from setting menu, too.
 |VimCtrlBracketNormal|If 1, pushing Ctrl-[ sets the normal mode, while long press Ctrl-[ sends Ctrl-[.|1|
 |VimSendCtrlBracketNormal|If 1, short press Ctrl-[ send Ctrl-[ in the normal mode.|0|
 |VimLongCtrlBracketNormal|If 1, short press and long press of Ctrl-[ behaviors are swapped.|0|
+|VimChangeCaretWidth|If 1, when entering normal mode, sets the text cursor/caret to a thick bar, then sets back to thin when exiting normal mode. Does not work with all windows, and causes the current window to briefly lose focus when changing mode.|0|
 |VimRestoreIME|If 1, IME status is restored at entering the insert mode.|1|
 |VimJJ|If 1, `jj` changes the mode to the normal mode from the insert mode.|0|
 |VimTwoLetterEsc|A list of character pairs to press together during the insert mode to get to the Normal mode.<br>For example, a value of `jf` means pressing `j` and `f` at the same time will enter the Normal mode.<br>Multiple combination can be set by separated by `,`. (e.g. `jf,jk,sd`)||

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -44,7 +44,7 @@ class VimAhk{
     ; Group Settings
     this.GroupDel := ","
     this.GroupN := 0
-    this.GroupName := "VimGroup" GroupN
+    this.GroupName := "VimGroup" this.GroupN
 
     DefaultGroup := this.SetDefaultActiveWindows()
 
@@ -71,6 +71,7 @@ class VimAhk{
     GroupAdd, VimCursorSameAfterSelect, ahk_exe explorer.exe ; Explorer
 
     ; Configuration values for Read/Write ini
+    ; setting, default, val, description, info
     this.Conf := {}
     this.AddToConf("VimEscNormal", 1, 1
       , "ESC to enter the normal mode"
@@ -93,6 +94,9 @@ class VimAhk{
     this.AddToConf("VimLongCtrlBracketNormal", 0, 0
       , "Long press Ctrl-[ to enter the normal mode:"
       , "Swap short press and long press behaviors for Ctrl-[.`nEnable Ctrl-[ to enter the normal mode first.")
+    this.AddToConf("VimChangeCaretWidth", 0, 0
+      , "Change to thick text caret when in normal mode"
+      , "When entering normal mode, sets the text cursor/caret to a thick bar, then sets back to thin when exiting normal mode.`nDoesn't work with all windows, and causes the current window to briefly lose focus when changing mode.")
     this.AddToConf("VimRestoreIME", 1, 1
       , "Restore IME status at entering the insert mode"
       , "Save the IME status in the insert mode, and restore it at entering the insert mode.")
@@ -121,7 +125,7 @@ class VimAhk{
       , "Application"
       , "Set one application per line.`n`nIt can be any of Window Title, Class or Process.`nYou can check these values by Window Spy (in the right click menu of tray icon).")
 
-    this.CheckBoxes := ["VimEscNormal", "VimSendEscNormal", "VimLongEscNormal", "VimCtrlBracketToEsc", "VimCtrlBracketNormal", "VimSendCtrlBracketNormal", "VimLongCtrlBracketNormal", "VimRestoreIME", "VimJJ"]
+    this.CheckBoxes := ["VimEscNormal", "VimSendEscNormal", "VimLongEscNormal", "VimCtrlBracketToEsc", "VimCtrlBracketNormal", "VimSendCtrlBracketNormal", "VimLongCtrlBracketNormal", "VimRestoreIME", "VimJJ", "VimChangeCaretWidth"]
 
     ; ToolTip Information
     this.Info := {}
@@ -148,6 +152,7 @@ class VimAhk{
 
   SetExistValue(){
     for k, v in this.Conf {
+      ; This ensures the variable exists, as a workaround since in AHK we cannot directly check whether it exists.
       if(%k% != ""){
         this.Conf[k]["default"] := %k%
         this.Conf[k]["val"] := %k%

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -7,6 +7,7 @@
 #Include %A_LineFile%\..\vim_check.ahk
 #Include %A_LineFile%\..\vim_gui.ahk
 #Include %A_LineFile%\..\vim_icon.ahk
+#Include %A_LineFile%\..\vim_caret.ahk
 #Include %A_LineFile%\..\vim_ini.ahk
 #Include %A_LineFile%\..\vim_menu.ahk
 #Include %A_LineFile%\..\vim_move.ahk
@@ -32,6 +33,7 @@ class VimAhk{
     this.About := new VimAbout(this)
     this.Check := new VimCheck(this)
     this.Icon := new VimIcon(this)
+    this.Caret := new VimCaret(this)
     this.Ini := new VimIni(this)
     this.VimMenu := new VimMenu(this)
     this.Move := new VimMove(this)

--- a/lib/vim_caret.ahk
+++ b/lib/vim_caret.ahk
@@ -1,6 +1,7 @@
 class VimCaret{
-  __New(){
+  __New(vim){
     global VimScriptPath
+    this.Vim := vim
     this.caretwidths := {"Normal": 10
                  , "Visual": 10
                  , "Insert": 1
@@ -9,14 +10,14 @@ class VimCaret{
 
   SetCaret(Mode="", Interval=0){
     width :=
-    if (Interval == 0){
-      width := this.caretwidths["Default"]
-    }else if InStr(Mode, "Normal"){
+    if this.Vim.State.IsCurrentVimMode("Vim_Normal"){
       width := this.caretwidths["Normal"]
-    }else if InStr(Mode, "Visual"){
+    }else if this.Vim.State.StrIsInCurrentVimMode("Visual"){
       width := this.caretwidths["Visual"]
-    }else {
+    }else if this.Vim.State.IsCurrentVimMode("Insert"){
       width := this.caretwidths["Insert"]
+    }else{
+      width := this.caretwidths["Default"]
     }
     SetCaretWidth(width)
   }
@@ -31,4 +32,14 @@ SetCaretWidth(width){
     SPIF_SENDCHANGE := 0x02
     fWinIni := SPIF_UPDATEINIFILE | SPIF_SENDCHANGE
     DllCall("SystemParametersInfo", UInt,SPI_SETCARETWIDTH, UInt,0, UInt,CARETWIDTH, UInt,fWinIni)
+    SwitchToSameWindow()
 }
+
+SwitchToSameWindow(){
+    ; Get ID of active window
+    WinGet, hwnd, ID, A
+    ; Activate desktop
+    winActivate, ahk_class WorkerW
+    WinActivate, ahk_id %hwnd%
+}
+

--- a/lib/vim_caret.ahk
+++ b/lib/vim_caret.ahk
@@ -1,0 +1,34 @@
+class VimCaret{
+  __New(){
+    global VimScriptPath
+    this.caretwidths := {"Normal": 10
+                 , "Visual": 10
+                 , "Insert": 1
+                 , "Default": 1}
+  }
+
+  SetCaret(Mode="", Interval=0){
+    width :=
+    if (Interval == 0){
+      width := this.caretwidths["Default"]
+    }else if InStr(Mode, "Normal"){
+      width := this.caretwidths["Normal"]
+    }else if InStr(Mode, "Visual"){
+      width := this.caretwidths["Visual"]
+    }else {
+      width := this.caretwidths["Insert"]
+    }
+    SetCaretWidth(width)
+  }
+}
+
+; Expects argument "width" in hex
+SetCaretWidth(width){
+    CARETWIDTH := width
+    ; SPI = SystemParametersInfo
+    SPI_SETCARETWIDTH := 0x2007
+    SPIF_UPDATEINIFILE := 0x01
+    SPIF_SENDCHANGE := 0x02
+    fWinIni := SPIF_UPDATEINIFILE | SPIF_SENDCHANGE
+    DllCall("SystemParametersInfo", UInt,SPI_SETCARETWIDTH, UInt,0, UInt,CARETWIDTH, UInt,fWinIni)
+}

--- a/lib/vim_caret.ahk
+++ b/lib/vim_caret.ahk
@@ -8,7 +8,10 @@ class VimCaret{
                  , "Default": 1}
   }
 
-  SetCaret(Mode="", Interval=0){
+  SetCaret(Mode=""){
+    if (this.Vim.Conf["VimChangeCaretWidth"]["val"] == 0){
+      return
+    }
     width :=
     if this.Vim.State.IsCurrentVimMode("Vim_Normal"){
       width := this.caretwidths["Normal"]

--- a/lib/vim_icon.ahk
+++ b/lib/vim_icon.ahk
@@ -1,6 +1,7 @@
 ﻿class VimIcon{
-  __New(){
+  __New(vim){
     global VimScriptPath
+    this.Vim := vim
     this.icons := {Normal: VimScriptPath "\..\vim_ahk_icons\normal.ico"
                  , Insert: VimScriptPath  "\..\vim_ahk_icons\insert.ico"
                  , Visual: VimScriptPath "\..\vim_ahk_icons\visual.ico"

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -1,11 +1,11 @@
-﻿class VimSetting Extends VimGui{
+class VimSetting Extends VimGui{
   __New(vim){
     this.Vim := vim
     base.__New(vim, "Vim Ahk Settings")
   }
 
   MakeGui(){
-    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal
+    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal, VimChangeCaretWidth
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     global VimDisableUnusedText, VimSetTitleMatchModeText, VimIconCheckIntervalText, VimIconCheckIntervalEdit, VimVerboseText, VimGroupText, VimHomepage, VimSettingOK, VimSettingReset, VimSettingCancel, VimTwoLetterText
     this.VimVal2V()
@@ -91,7 +91,7 @@
   }
 
   UpdateGuiValue(){
-    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal
+    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal, VimChangeCaretWidth
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     for i, k in this.Vim.Checkboxes {
       GuiControl, % this.Hwnd ":", % k, % %k%
@@ -135,7 +135,7 @@
   }
 
   VimV2Conf(){
-    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal
+    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal, VimChangeCaretWidth
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetter, VimTwoLetterList
     VimGroup := this.VimParseList(VimGroupList)
     VimTwoLetter := this.VimParseList(VimTwoLetterList)
@@ -162,7 +162,7 @@
   }
 
   VimConf2V(vd){
-    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal
+    global VimRestoreIME, VimJJ, VimEscNormal, VimSendEscNormal, VimLongEscNormal, VimCtrlBracketToEsc, VimCtrlBracketNormal, VimSendCtrlBracketNormal, VimLongCtrlBracketNormal, VimChangeCaretWidth
     global VimDisableUnused, VimSetTitleMatchMode, VimSetTitleMatchModeFS, VimIconCheckInterval, VimVerbose, VimGroup, VimGroupList, VimTwoLetterList
     StringReplace, VimGroupList, % this.Vim.Conf["VimGroup"][vd], % this.Vim.GroupDel, `n, All
     StringReplace, VimTwoLetterList, % this.Vim.Conf["VimTwoLetter"][vd], % this.Vim.GroupDel, `n, All

--- a/lib/vim_state.ahk
+++ b/lib/vim_state.ahk
@@ -183,6 +183,7 @@
   StatusCheck(){
     if WinActive("ahk_group " this.Vim.GroupName){
       this.Vim.Icon.SetIcon(this.Mode, this.Vim.Conf["VimIconCheckInterval"]["val"])
+      this.Vim.Caret.SetCaret(this.Mode, this.Vim.Conf["VimIconCheckInterval"]["val"])
     }else{
       this.Vim.Icon.SetIcon("Disabled", this.Vim.Conf["VimIconCheckInterval"]["val"])
     }

--- a/lib/vim_state.ahk
+++ b/lib/vim_state.ahk
@@ -23,16 +23,16 @@
     if(force == 0) and ((verbose <= 1) or ((Mode == "") and (g == 0) and (n == 0) and (LineCopy == -1))){
       Return
     }else if(verbose == 2){
-      this.Status(this.Mode, 1)
+      this.SetTooltip(this.Mode, 1)
     }else if(verbose == 3){
-      this.Status(this.Mode "`r`ng=" this.g "`r`nn=" this.n "`r`nLineCopy=" this.LineCopy, 4)
+      this.SetTooltip(this.Mode "`r`ng=" this.g "`r`nn=" this.n "`r`nLineCopy=" this.LineCopy, 4)
     }
     if(verbose >= 4){
       Msgbox, , Vim Ahk, % "Mode: " this.Mode "`nVim_g: " this.g "`nVim_n: " this.n "`nVimLineCopy: " this.LineCopy
     }
   }
 
-  Status(Title, lines=1){
+  SetTooltip(Title, lines=1){
     WinGetPos, , , W, H, A
     ToolTip, %Title%, W - 110, H - 30 - (lines) * 20
     this.Vim.VimToolTip.SetRemoveToolTip(1000)
@@ -50,6 +50,7 @@
         VIM_IME_SET(this.LastIME)
       }
       this.Vim.Icon.SetIcon(this.Mode, this.Vim.Conf["VimIconCheckInterval"]["val"])
+      this.Vim.Caret.SetCaret(this.Mode, this.Vim.Conf["VimIconCheckInterval"]["val"])
     }
     if(g != -1){
       this.g := g
@@ -180,10 +181,10 @@
     return false
   }
 
+  ; Update icon/mode indicator
   StatusCheck(){
     if WinActive("ahk_group " this.Vim.GroupName){
       this.Vim.Icon.SetIcon(this.Mode, this.Vim.Conf["VimIconCheckInterval"]["val"])
-      this.Vim.Caret.SetCaret(this.Mode, this.Vim.Conf["VimIconCheckInterval"]["val"])
     }else{
       this.Vim.Icon.SetIcon("Disabled", this.Vim.Conf["VimIconCheckInterval"]["val"])
     }


### PR DESCRIPTION
Fix #47

Doesn't work in all apps (Chrome, for example), but does work in notepad and Onenote