### PR TITLE
Add keybinds refer to ranger which is a console file manager with VI for the Q-Dir.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "AutoHotkey Debug",
+            "type": "autohotkey",
+            "request": "launch",
+            "program": "${workspaceFolder}\\vim.ahk",
+            "args": [],
+            "runtime": "D:\\Program Files\\AutoHotkey\\AutoHotkeyU64.exe"
+        }
+
+    ],
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You will find **vim_ahk** folder which contains **vim_ahk.exe** and **vim_ahk_ic
 ## Applications (VimGroup)
 The default setting enables vim-mode for the following applications:
 
+* Q-dir
 * Notepad (メモ帳)
 * Wordpad
 * TeraPad
@@ -229,7 +230,8 @@ If using a custom two-letter hotkey to enter the normal mode, the two letters mu
 
 |Key/Commands|Function|
 |:----------:|:-------|
-|h/j/k/l|Left/Down/Up/Right.|
+|h/j/k/l|Left/Down/Up/Right in other applications.|
+|h/j/k/l|Backspace(returns to the parent directory)/Down/Up/Enter(enters the selected directory or opens a file) in q-dir.|
 |0/$| To the start/end of the line.|
 |Ctrl-a/Ctrl-e| To the start/end of the line (emacs like).|
 |^| To the starting non-whitespace character of the line.|

--- a/README.md
+++ b/README.md
@@ -231,7 +231,6 @@ If using a custom two-letter hotkey to enter the normal mode, the two letters mu
 |Key/Commands|Function|
 |:----------:|:-------|
 |h/j/k/l|Left/Down/Up/Right in other applications.|
-|h/j/k/l|Backspace(returns to the parent directory)/Down/Up/Enter(enters the selected directory or opens a file) in q-dir.|
 |0/$| To the start/end of the line.|
 |Ctrl-a/Ctrl-e| To the start/end of the line (emacs like).|
 |^| To the starting non-whitespace character of the line.|
@@ -248,6 +247,15 @@ In addition, `Repeat` is also available for some commands.
 |4j| Down 4 lines|
 |3w| Move 3 words forward|
 |100j| Down 100 lines|
+
+### Q-dir
+The keybinds refer to [ranger](https://github.com/ranger/ranger) which is a console file manager with VI key bindings
+
+|Key/Commands|Function|
+|:----------:|:-------|
+|h/j/k/l|Backspace(returns to the parent directory)/Down/Up/Enter(enters the selected directory or opens a file)|
+|Alt+u/i/j/k| switch between Quad-Directories|
+|'| menu Quick-links|
 
 ### Yank/Cut(Delete)/Change/Paste
 

--- a/lib/bind/vim_enter_insert.ahk
+++ b/lib/bind/vim_enter_insert.ahk
@@ -25,3 +25,10 @@ Return
   Send, {Home}{Enter}{Left}
   Vim.State.SetMode("Insert")
 Return
+
+; Q-dir
+#If WinActive("ahk_group VimQdir") and (Vim.State.Mode == "Vim_Normal")
+; 进入无autohotkey模式，可以通过首字母来快速定位文件/文件夹
+/::Vim.State.SetMode("Insert")
+; 重命名，自动进入insert模式
+~F2::Vim.State.SetMode("Insert")

--- a/lib/bind/vim_normal.ahk
+++ b/lib/bind/vim_normal.ahk
@@ -82,3 +82,7 @@ Return
     Send, {q Up}
     Send, {LControl Up}
 Return
+
+; 保留Normal模式下e键，用于右键再按下刷新(e)功能，啥事不干，直接返回e键
+~e::
+Return

--- a/lib/bind/vim_normal.ahk
+++ b/lib/bind/vim_normal.ahk
@@ -39,3 +39,46 @@ Space::Send, {Right}
 
 ; period
 .::Send, +^{Right}{BS}^v
+
+; Q-dir
+#If WinActive("ahk_group VimQdir") and (Vim.State.Mode == "Vim_Normal")
+; switch to left up panel
+; 使用ctrl无法正常工作, 改用alt更加顺手
+!u::
+    Send, {LControl Down}
+    Send, {1 Down}
+    Send, {1 Up}
+    Send, {LControl Up}
+Return
+
+; switch to right up panel
+!i::
+    Send, {LControl Down}
+    Send, {2 Down}
+    Send, {2 Up}
+    Send, {LControl Up}
+Return
+
+; switch to left down panel
+!j::
+    Send, {LControl Down}
+    Send, {3 Down}
+    Send, {3 Up}
+    Send, {LControl Up}
+Return
+
+; switch to right down panel
+!k::
+    Send, {LControl Down}
+    Send, {4 Down}
+    Send, {4 Up}
+    Send, {LControl Up}
+Return
+
+; Ctrl+q, menu Quick-links
+'::
+    Send, {LControl Down}
+    Send, {q Down}
+    Send, {q Up}
+    Send, {LControl Up}
+Return

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -68,6 +68,8 @@ class VimAhk{
     GroupAdd, VimCursorSameAfterSelect, ahk_exe notepad.exe ; NotePad
     GroupAdd, VimCursorSameAfterSelect, ahk_exe explorer.exe ; Explorer
 
+    ; Q-Dir should be a new group
+    GroupAdd, VimQdir, ahk_exe Q-Dir_x64.exe ; q-dir
     ; Configuration values for Read/Write ini
     this.Conf := {}
     this.AddToConf("VimEscNormal", 1, 1

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -109,9 +109,19 @@
 
       ; 1 character
       if(key == "h"){
-        Send, {Left}
+        if WinActive("ahk_group VimQdir"){
+          Send, {BackSpace down}{BackSpace up}
+        }
+        else {
+          Send, {Left}
+        }
       }else if(key == "l"){
-        Send, {Right}
+        if WinActive("ahk_group VimQdir"){
+          Send, {Enter}
+        }
+        else {
+          Send, {Right}
+        }
       ; Home/End
       }else if(key == "0"){
         this.Home()


### PR DESCRIPTION
Q-Dir the Quad Explorer for Microsoft's Windows Desktop and Server.
I think it is very useful in high resoution screen as it can provides 4 windows. But it lacks the vi sytle keybinds.
So i have add some keybinds in vi sytle to improve.