### PR TITLE
Fix move for letter "e"

### DIFF
--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -158,9 +158,9 @@
         }
       }else if(key == "e"){
         if(this.shift == 1){
-          Send, +^{Right}+^{Right}+{Left}
+          Send, +^{Right}+{Left}
         }else{
-          Send, ^{Right}^{Right}{Left}
+          Send, ^{Right}{Left}
         }
       }else if(key == "b"){
         if(this.shift == 1){


### PR DESCRIPTION
Motion for letter "e" should be implemented as: move to the beginning of the next word and move one character left, so Ctrl + Right once and Left