### PR TITLE
Fix: use := for VimAppList v['val'] assignments to persist setting (AHK v2)

### DIFF
--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -164,11 +164,11 @@ class VimSetting Extends VimGui{
         }
       }else if(k == "VimAppList"){
         if(this.Obj[k].Value == 1){
-          v["val"] = "All"
+          v["val"] := "All"
         }else if(this.Obj[k].Value == 2){
-          v["val"] = "Allow List"
+          v["val"] := "Allow List"
         }else{
-          v["val"] = "Deny List"
+          v["val"] := "Deny List"
         }
       }else{
         v["val"] := this.Obj[k].Value


### PR DESCRIPTION
 Changing settings for "Application List Usage" in the GUI does not save the change to vim_ahk.ini because VimV2Conf() function in vim_setting.ahk uses legacy "=" assignments instead of expression ":=" when setting v["val"] for VimAppList.