### PR TITLE
fix: G (go to bottom) not working in non-editor apps

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,14 +1,11 @@
-on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+on: [push]
 
 name: Build
 
 jobs:
   build:
     name: Build
+    if: startsWith( github.ref, 'refs/tags/v' )
     runs-on: windows-latest
     permissions:
       contents: write
@@ -30,14 +27,8 @@ jobs:
       - name: zip
         shell: pwsh
         run:
-          Compress-Archive -Path "vim_ahk" -DestinationPath vim_ahk-${{github.ref_name}}.zip
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: vim_ahk
-          path: vim_ahk/
+          Compress-Archive -Path "vim_ahk"  -DestinationPath vim_ahk-${{github.ref_name}}.zip
       - name: Create Release
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,11 +1,14 @@
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
 
 name: Build
 
 jobs:
   build:
     name: Build
-    if: startsWith( github.ref, 'refs/tags/v' )
     runs-on: windows-latest
     permissions:
       contents: write
@@ -27,8 +30,14 @@ jobs:
       - name: zip
         shell: pwsh
         run:
-          Compress-Archive -Path "vim_ahk"  -DestinationPath vim_ahk-${{github.ref_name}}.zip
+          Compress-Archive -Path "vim_ahk" -DestinationPath vim_ahk-${{github.ref_name}}.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vim_ahk
+          path: vim_ahk/
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -53,9 +53,16 @@ class VimAhk{
     DefaultGroup := this.SetDefaultActiveWindows()
 
     ; On following applications, Enter works as Enter at the normal mode.
+    ; Also, {Home} after Ctrl+End scrolls to top, so G skips {Home} for these.
     GroupAdd("VimNonEditor", "ahk_exe explorer.exe")  ; Explorer
     GroupAdd("VimNonEditor", "ahk_exe q-dir_x64.exe") ; Q-dir
     GroupAdd("VimNonEditor", "ahk_exe q-dir.exe")     ; Q-dir
+    GroupAdd("VimNonEditor", "ahk_exe chrome.exe")    ; Google Chrome
+    GroupAdd("VimNonEditor", "ahk_exe msedge.exe")    ; Microsoft Edge
+    GroupAdd("VimNonEditor", "ahk_exe firefox.exe")   ; Firefox
+    GroupAdd("VimNonEditor", "ahk_exe brave.exe")     ; Brave
+    GroupAdd("VimNonEditor", "ahk_exe vivaldi.exe")   ; Vivaldi
+    GroupAdd("VimNonEditor", "ahk_exe opera.exe")     ; Opera
 
     ; Following applications select the line break at Shift + End.
     GroupAdd("VimLBSelectGroup", "ahk_exe powerpnt.exe") ; PowerPoint

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -53,13 +53,14 @@ class VimAhk{
     DefaultGroup := this.SetDefaultActiveWindows()
 
     ; On following applications, Enter works as Enter at the normal mode.
-    ; Also, {Home} after Ctrl+End scrolls to top, so G skips {Home} for these.
+    ; G sends {End} (not Ctrl+End) to scroll to bottom in these apps.
     GroupAdd("VimNonEditor", "ahk_exe explorer.exe")  ; Explorer
     GroupAdd("VimNonEditor", "ahk_exe q-dir_x64.exe") ; Q-dir
     GroupAdd("VimNonEditor", "ahk_exe q-dir.exe")     ; Q-dir
     GroupAdd("VimNonEditor", "ahk_exe chrome.exe")    ; Google Chrome
     GroupAdd("VimNonEditor", "ahk_exe msedge.exe")    ; Microsoft Edge
     GroupAdd("VimNonEditor", "ahk_exe firefox.exe")   ; Firefox
+    GroupAdd("VimNonEditor", "ahk_exe waterfox.exe")  ; Waterfox
     GroupAdd("VimNonEditor", "ahk_exe brave.exe")     ; Brave
     GroupAdd("VimNonEditor", "ahk_exe vivaldi.exe")   ; Vivaldi
     GroupAdd("VimNonEditor", "ahk_exe opera.exe")     ; Opera

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -202,7 +202,11 @@
     }else if(Key == "g"){
       SendInput("^{Home}")
     }else if(Key == "+g"){
-      SendInput("^{End}{Home}")
+      if WinActive("ahk_group VimNonEditor"){
+        SendInput("^{End}")
+      } else {
+        SendInput("^{End}{Home}")
+      }
     }
 
     if(!Repeat){

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -203,7 +203,7 @@
       SendInput("^{Home}")
     }else if(Key == "+g"){
       if WinActive("ahk_group VimNonEditor"){
-        SendInput("^{End}")
+        SendInput("{End}")
       } else {
         SendInput("^{End}{Home}")
       }


### PR DESCRIPTION
## Problem

In non-editor apps like browsers and file explorers, the `G` command (`Shift+g`, go to bottom) fails to scroll to the bottom.

## Root Cause

1. `Ctrl+End` doesn't work in some browsers (e.g. Waterfox) — only plain `End` scrolls to bottom
2. `{Home}` sent after `Ctrl+End` scrolls back to the top in browsers, undoing the scroll

## Fix

- For apps in the `VimNonEditor` group, `G` now sends `{End}` instead of `^{End}{Home}`
- Added common browsers to `VimNonEditor` group: Chrome, Edge, Firefox, Waterfox, Brave, Vivaldi, Opera

## Testing

Verified that `G` correctly scrolls to the bottom in Waterfox and other browser windows.