### PR TITLE
Fix/search repeat behavior

### DIFF
--- a/lib/bind/vim_search.ahk
+++ b/lib/bind/vim_search.ahk
@@ -19,7 +19,7 @@
   A_Clipboard := ClipSaved
   Vim.State.SearchActive := true
   Vim.State.SearchHwnd := WinGetID("A")
-  Vim.State.SetMode("Insert")
+  Vim.State.SetMode("Vim_Normal")
 }
 
 n::

--- a/lib/bind/vim_search.ahk
+++ b/lib/bind/vim_search.ahk
@@ -11,7 +11,9 @@
   A_Clipboard := ""
   SendInput("^{Left}+^{Right}^c")
   ClipWait(1)
-  SendInput("^f^v!f")
+  SendInput("{Right}")
+  SendInput("^f^v{Enter}")
+  Sleep(150)
   A_Clipboard := ClipSaved
   Vim.State.SetMode("Insert")
 }

--- a/lib/bind/vim_search.ahk
+++ b/lib/bind/vim_search.ahk
@@ -2,6 +2,8 @@
 /::
 {
   SendInput("^f")
+  Vim.State.SearchActive := true
+  Vim.State.SearchHwnd := WinGetID("A")
   Vim.State.SetMode("Insert")
 }
 
@@ -15,10 +17,21 @@
   SendInput("^f^v{Enter}")
   Sleep(150)
   A_Clipboard := ClipSaved
+  Vim.State.SearchActive := true
+  Vim.State.SearchHwnd := WinGetID("A")
   Vim.State.SetMode("Insert")
 }
 
-n::SendInput("{F3}")
-+n::SendInput("+{F3}")
+n::
+{
+  if Vim.State.HasSearchReady()
+    SendInput("{F3}")
+}
+
++n::
+{
+  if Vim.State.HasSearchReady()
+    SendInput("+{F3}")
+}
 
 #HotIf

--- a/lib/vim_state.ahk
+++ b/lib/vim_state.ahk
@@ -20,8 +20,21 @@
     this.LastIME := 0
     this.CurrControl := ""
     this.PrevControl := ""
+    this.SearchActive := false
+    this.SearchHwnd := 0
 
     this.StatusCheckObj := ObjBindMethod(this, "StatusCheck")
+  }
+
+  HasSearchReady(){
+    if !this.SearchActive
+      return false
+    if !WinActive("ahk_id " this.SearchHwnd){
+      this.SearchActive := false
+      this.SearchHwnd := 0
+      return false
+    }
+    return true
   }
 
   CheckMode(Verbose:=1, Mode:="", g:=0, n:=0, LineCopy:=-1, Force:=0){


### PR DESCRIPTION
## Motivation

1. **`*` search word duplication in Electron apps**: After `*` copies the word under the cursor, the selection remains active. When Electron apps open the search box with `Ctrl+F`, they auto-fill it with the current selection. The script then pastes via `Ctrl+V` again, resulting in a doubled search term (e.g. "his" → "hishis"). The original implementation also uses `Alt+F` to trigger the Find button accelerator key, which works well in traditional Windows Find dialogs, but in Electron apps `Alt+F` opens the File menu instead. Replaced with `Enter` as the universal search execution key. After switching to `Enter`, the clipboard restore was occasionally racing with the app consuming `Ctrl+V`, causing the search term to revert to old clipboard content. Adding `Sleep(150)` before the restore resolves this reliably — whether this is an inherent sequencing issue or an intermittent race is unclear, but 150ms is imperceptible to the user and stable in testing.

2. **`n`/`N` unconditionally sending `F3`**: `F3` is commonly mapped to other functions in many user environments (screenshot tools, file viewers, etc.). Sending `F3` without an active search context can trigger unintended behavior. This PR adds window-level search context: `/` and `*` mark the current window as search-active, and `n`/`N` only sends `F3`/`Shift+F3` when this context is valid. Regarding lifetime: in traditional vim, the search register is permanent because vim holds the search content internally and can reuse it across buffers. vim_ahk delegates search entirely to the host app's `Ctrl+F` and holds no search content itself. If the state were kept permanently, pressing `n` in a window whose context has long since changed would unexpectedly fire `F3`. The current design clears the search context on window switch — the user must re-initiate a search to use `n`/`N`.

3. **`*` should return to normal mode**: `*` is a normal mode search command — after execution, the user typically continues with `n`/`N` or other normal mode operations, so staying in normal mode is more natural. `/` is different: it opens the search box for the user to type a search term, so entering Insert mode is correct.

## Changes

### 1. Fix `*` search behavior (`lib/bind/vim_search.ahk`)

- Send `{Right}` after copying the word to clear the selection before opening the search box
- Replace `Alt+F` with `{Enter}`
- Add `Sleep(150)` before restoring the clipboard

### 2. Guard `n`/`N` with search context (`lib/vim_state.ahk`, `lib/bind/vim_search.ahk`)

- Add `SearchActive`, `SearchHwnd`, and `HasSearchReady()` to `VimState`
- Record search context when `/` or `*` is used
- `n`/`N` only sends `F3`/`Shift+F3` when `HasSearchReady()` returns true
- Search context is cleared on window switch

### 3. Stay in normal mode after `*` (`lib/bind/vim_search.ahk`)

- Change `SetMode("Insert")` to `SetMode("Vim_Normal")`

## Testing

- Tested `*`, `/`, `n`, `N` in Obsidian
- `*` search term no longer duplicates, no menu triggered
- `n`/`N` does nothing when no search has been initiated; works normally after `/` or `*`
- Search context clears on window switch; re-initiating search restores it
- `*` stays in normal mode, `n`/`N` immediately usable afterward
