### PR TITLE
feat: add app-specific line break handling for o and +o in insert mode

### DIFF
--- a/lib/bind/vim_enter_insert.ahk
+++ b/lib/bind/vim_enter_insert.ahk
@@ -23,13 +23,25 @@ a::
 
 o::
 {
-  SendInput("{End}{Enter}")
+  if WinActive("ahk_group VimShiftEnter"){
+    SendInput("{End}+{Enter}")
+  } else if WinActive("ahk_group VimCtrlEnter"){
+    SendInput("{End}^{Enter}")
+  } else {
+    SendInput("{End}{Enter}")
+  }
   Vim.State.SetMode("Insert")
 }
 
 +o::
 {
-  SendInput("{Home}{Enter}{Left}")
+  if WinActive("ahk_group VimShiftEnter"){
+    SendInput("{Home}+{Enter}{Left}")
+  } else if WinActive("ahk_group VimCtrlEnter"){
+    SendInput("{Home}^{Enter}{Left}")
+  } else {
+    SendInput("{Home}{Enter}{Left}")
+  }
   Vim.State.SetMode("Insert")
 }
 

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -93,6 +93,22 @@ class VimAhk{
     GroupAdd("VimQdir", "ahk_exe q-dir_x64.exe") ; q-dir
     GroupAdd("VimQdir", "ahk_exe q-dir.exe") ; q-dir
 
+    ; Shift-Enter to insert line break in these applications
+    GroupAdd("VimShiftEnter", "ahk_exe ChatGPT.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe Claude.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe Cursor.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe slack.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe ms-teams.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe Teams.exe") ; Old version
+    GroupAdd("VimShiftEnter", "ahk_exe Discord.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe WhatsApp.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe Zoom.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe PhoneExperienceHost.exe") ;
+    GroupAdd("VimShiftEnter", "ahk_exe LINE.exe") ;
+
+    ; Control-Enter to insert line break in these applications
+    ;GroupAdd("VimCtrlEnter", "ahk_exe LINE.exe") ;
+
     ; Configuration values for Read/Write ini
     ; setting, default, val, description, info
     this.Conf := Map()


### PR DESCRIPTION
Some applications, such as ChatGPT, use Enter to send a message and require Shift+Enter or Ctrl+Enter to insert a line break.

In Normal mode, vim_ahk currently sends Enter when executing `o` or `O`. In these applications, this may send the current message instead of opening a new line.

This PR adds the `VimShiftEnter` and `VimCtrlEnter` application groups and uses the appropriate key combination when handling `o` and `O`.

For now, these groups are hard-coded, so users need to edit the vim_ahk script directly to add or change applications.

Current list:

```
    ; Shift-Enter to insert line break in these applications
    GroupAdd("VimShiftEnter", "ahk_exe ChatGPT.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe Claude.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe Cursor.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe slack.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe ms-teams.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe Teams.exe") ; Old version
    GroupAdd("VimShiftEnter", "ahk_exe Discord.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe WhatsApp.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe Zoom.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe PhoneExperienceHost.exe") ;
    GroupAdd("VimShiftEnter", "ahk_exe LINE.exe") ;

    ; Control-Enter to insert line break in these applications
    ; No corresponding applications
```

Making these groups configurable from the settings window would be useful. However, adding more application-specific options there would make the window increasingly complex, while several other settings also remain hard-coded. A separate configuration mechanism may eventually be needed to manage these settings (#129).

Partially addresses #128.