### PR TITLE
Feature/schema driven settings

### DIFF
--- a/lib/bind/vim_enter_insert.ahk
+++ b/lib/bind/vim_enter_insert.ahk
@@ -23,9 +23,9 @@ a::
 
 o::
 {
-  if WinActive("ahk_group VimShiftEnter"){
+  if Vim.IsConfiguredGroup("VimShiftEnter"){
     SendInput("{End}+{Enter}")
-  } else if WinActive("ahk_group VimCtrlEnter"){
+  } else if Vim.IsConfiguredGroup("VimCtrlEnter"){
     SendInput("{End}^{Enter}")
   } else {
     SendInput("{End}{Enter}")
@@ -35,9 +35,9 @@ o::
 
 +o::
 {
-  if WinActive("ahk_group VimShiftEnter"){
+  if Vim.IsConfiguredGroup("VimShiftEnter"){
     SendInput("{Home}+{Enter}{Left}")
-  } else if WinActive("ahk_group VimCtrlEnter"){
+  } else if Vim.IsConfiguredGroup("VimCtrlEnter"){
     SendInput("{Home}^{Enter}{Left}")
   } else {
     SendInput("{Home}{Enter}{Left}")
@@ -46,7 +46,7 @@ o::
 }
 
 ; Q-dir
-#HotIf Vim.IsVimGroup() and WinActive("ahk_group VimQdir") and (Vim.State.Mode == "Vim_Normal")
+#HotIf Vim.IsVimGroup() and Vim.IsConfiguredGroup("VimQdir") and (Vim.State.Mode == "Vim_Normal")
 ; Enter insert mode to quickly locate the file/folder by using the first letter
 /::Vim.State.SetMode("Insert")
 ; Enter insert mode at rename

--- a/lib/bind/vim_move.ahk
+++ b/lib/bind/vim_move.ahk
@@ -44,7 +44,7 @@ b::Vim.Move.Repeat("b")
 +g::Vim.Move.Move("+g")
 ; Space
 Space::Vim.Move.Repeat("l")
-#HotIf Vim.IsVimGroup() and (Vim.State.StrIsInCurrentVimMode("Vim_")) and not WinActive("ahk_group VimNonEditor")
+#HotIf Vim.IsVimGroup() and (Vim.State.StrIsInCurrentVimMode("Vim_")) and not Vim.IsConfiguredGroup("VimNonEditor")
 ; Enter
 Enter::
 {

--- a/lib/bind/vim_normal.ahk
+++ b/lib/bind/vim_normal.ahk
@@ -44,7 +44,7 @@ u::SendInput("^z")
 }
 
 ; Q-dir
-#HotIf Vim.IsVimGroup() and WinActive("ahk_group VimQdir") and (Vim.State.Mode == "Vim_Normal")
+#HotIf Vim.IsVimGroup() and Vim.IsConfiguredGroup("VimQdir") and (Vim.State.Mode == "Vim_Normal")
 ; For Q-dir, ^X mapping does not work, use !X instead.
 ; ^X does not work to be sent, too, use Down/Up
 ; Switch to left top (1), right top (2), left bottom (3), right bottom (4).

--- a/lib/bind/vim_visual.ahk
+++ b/lib/bind/vim_visual.ahk
@@ -22,7 +22,7 @@ y::
 {
   A_Clipboard := ""
   SendInput("^c{Right}")
-  if WinActive("ahk_group VimCursorSameAfterSelect"){
+  if Vim.IsConfiguredGroup("VimCursorSameAfterSelect"){
     SendInput("{Left}")
   }
   ClipWait(1)

--- a/lib/bind/vim_ydcxp.ahk
+++ b/lib/bind/vim_ydcxp.ahk
@@ -6,11 +6,11 @@ c::Vim.State.SetMode("Vim_ydc_c", 0, -1, 0)
 {
   Vim.State.SetMode("Vim_ydc_y", 0, 0, 1)
   Sleep(150) ; Need to wait (For variable change?)
-  if WinActive("ahk_group VimDoubleHomeGroup"){
+  if Vim.IsConfiguredGroup("VimDoubleHomeGroup"){
     SendInput("{Home}")
   }
   SendInput("{Home}+{End}")
-  if not WinActive("ahk_group VimLBSelectGroup"){
+  if not Vim.IsConfiguredGroup("VimLBSelectGroup"){
     Vim.Move.Move("l")
   }else{
     Vim.Move.Move("")
@@ -21,7 +21,7 @@ c::Vim.State.SetMode("Vim_ydc_c", 0, -1, 0)
 +d::
 {
   Vim.State.SetMode("Vim_ydc_d", 0, 0, 0)
-  if not WinActive("ahk_group VimLBSelectGroup"){
+  if not Vim.IsConfiguredGroup("VimLBSelectGroup"){
     Vim.Move.Move("$")
   }else{
     SendInput("{Shift Down}{End}{Left}")
@@ -32,7 +32,7 @@ c::Vim.State.SetMode("Vim_ydc_c", 0, -1, 0)
 +c::
 {
   Vim.State.SetMode("Vim_ydc_c",0,0,0)
-  if not WinActive("ahk_group VimLBSelectGroup"){
+  if not Vim.IsConfiguredGroup("VimLBSelectGroup"){
     Vim.Move.Move("$")
   }else{
     SendInput("{Shift Down}{End}{Left}")
@@ -88,7 +88,7 @@ p::
   ;  break
   ;}
   if(Vim.State.LineCopy == 1){
-    if WinActive("ahk_group VimNoLBCopyGroup"){
+    if Vim.IsConfiguredGroup("VimNoLBCopyGroup"){
       SendInput("{End}{Enter}^v{Home}")
     }else{
       SendInput("{End}{Enter}^v{BS}{Home}")

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -77,31 +77,9 @@ class VimAhk{
   }
 
   SetValues(Values){
-    this.ValidateLineBreakGroups(Values)
+    VimSettingSchema.ValidateExclusiveGroups(this.Conf, Values, this.GroupDel)
     for Key, Value in Values {
       this.Conf[Key]["val"] := Value
-    }
-  }
-
-  ValidateLineBreakGroups(Values){
-    ShiftApps := Map()
-    Loop Parse, Values["VimShiftEnter"], this.GroupDel {
-      if (A_LoopField != "") {
-        ShiftApps[StrLower(A_LoopField)] := A_LoopField
-      }
-    }
-
-    Conflicts := ""
-    Loop Parse, Values["VimCtrlEnter"], this.GroupDel {
-      if (A_LoopField != "" && ShiftApps.Has(StrLower(A_LoopField))) {
-        Conflicts .= (Conflicts == "" ? "" : "`n") A_LoopField
-      }
-    }
-
-    if (Conflicts != "") {
-      throw ValueError("Choose one line-break method for each application.`n"
-        . "The following entries appear in both Shift+Enter and Ctrl+Enter:`n`n"
-        . Conflicts)
     }
   }
 

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -83,6 +83,9 @@ class VimAhk{
     }
   }
 
+  ; AutoHotkey can only append rules to window groups; existing rules cannot be cleared.
+  ; Whenever settings are applied, new groups are built before the current mapping is replaced.
+  ; Old groups remain until the script exits and are no longer queried.
   SetConfiguredGroups(){
     this.ConfiguredGroupN++
     Groups := Map()
@@ -130,6 +133,9 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
+    Values := VimSettingSchema.NormalizeValues(
+      this.Conf, VimSettingSchema.Values(this.Conf), this.GroupDel)
+    this.SetValues(Values)
     this.VimMenu.SetMenu()
     this.Setup()
   }

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -12,7 +12,6 @@
 #Include %A_LineFile%\..\vim_menu.ahk
 #Include %A_LineFile%\..\vim_move.ahk
 #Include %A_LineFile%\..\vim_setting_schema.ahk
-#Include %A_LineFile%\..\vim_setting_panel.ahk
 #Include %A_LineFile%\..\vim_setting.ahk
 #Include %A_LineFile%\..\vim_state.ahk
 #Include %A_LineFile%\..\vim_tooltip.ahk
@@ -47,148 +46,15 @@ class VimAhk{
     this.State := VimState(this)
     this.VimToolTip := VimToolTip(this)
 
-    ; Group Settings
+    ; Configuration values for Read/Write ini and settings GUI
     this.GroupDel := ","
     this.GroupN := 0
     this.GroupName := "VimGroup" this.GroupN
-
     DefaultGroup := this.SetDefaultActiveWindows()
-
-    ; On following applications, Enter works as Enter at the normal mode.
-    ; G sends {End} (not Ctrl+End) to scroll to bottom in these apps.
-    GroupAdd("VimNonEditor", "ahk_exe explorer.exe")  ; Explorer
-    GroupAdd("VimNonEditor", "ahk_exe q-dir_x64.exe") ; Q-dir
-    GroupAdd("VimNonEditor", "ahk_exe q-dir.exe")     ; Q-dir
-    GroupAdd("VimNonEditor", "ahk_exe chrome.exe")    ; Google Chrome
-    GroupAdd("VimNonEditor", "ahk_exe msedge.exe")    ; Microsoft Edge
-    GroupAdd("VimNonEditor", "ahk_exe firefox.exe")   ; Firefox
-    GroupAdd("VimNonEditor", "ahk_exe waterfox.exe")  ; Waterfox
-    GroupAdd("VimNonEditor", "ahk_exe brave.exe")     ; Brave
-    GroupAdd("VimNonEditor", "ahk_exe vivaldi.exe")   ; Vivaldi
-    GroupAdd("VimNonEditor", "ahk_exe opera.exe")     ; Opera
-
-    ; Following applications select the line break at Shift + End.
-    GroupAdd("VimLBSelectGroup", "ahk_exe powerpnt.exe") ; PowerPoint
-    GroupAdd("VimLBSelectGroup", "ahk_exe winword.exe")  ; Word
-    GroupAdd("VimLBSelectGroup", "ahk_exe wordpad.exe")  ; WordPad
-    GroupAdd("VimLBSelectGroup", "ahk_exe notepad.exe")  ; Notepad
-
-    ; Following applications do not copy the line break
-    GroupAdd("VimNoLBCopyGroup", "ahk_exe evernote.exe") ; Evernote
-
-    ; Need Ctrl for Up/Down
-    GroupAdd("VimCtrlUpDownGroup", "ahk_exe onenote.exe") ; OneNote Desktop, before Windows 10
-
-    ; Need Home twice
-    GroupAdd("VimDoubleHomeGroup", "ahk_exe code.exe") ; Visual Studio Code
-
-    ; The following can emulate ^. For others, ^ works the same as 0.
-    ; It does not work for Notepad on Windows 11.
-    ; GroupAdd("VimCaretMove", "ahk_exe notepad.exe") ; Notepad
-
-    ; The following start cursor from the same place after selection.
-    ; Others start right/left (by cursor) point of the selection
-    GroupAdd("VimCursorSameAfterSelect", "ahk_exe notepad.exe") ; Notepad
-    GroupAdd("VimCursorSameAfterSelect", "ahk_exe explorer.exe") ; Explorer
-
-    ; Q-Dir
-    GroupAdd("VimQdir", "ahk_exe q-dir_x64.exe") ; q-dir
-    GroupAdd("VimQdir", "ahk_exe q-dir.exe") ; q-dir
-
-    ; Shift-Enter to insert line break in these applications
-    GroupAdd("VimShiftEnter", "ahk_exe ChatGPT.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Claude.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Cursor.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe slack.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe ms-teams.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Teams.exe") ; Old version
-    GroupAdd("VimShiftEnter", "ahk_exe Discord.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe WhatsApp.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Zoom.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe PhoneExperienceHost.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe LINE.exe") ;
-
-    ; Control-Enter to insert line break in these applications
-    ;GroupAdd("VimCtrlEnter", "...") ;
-
-    ; Configuration values for Read/Write ini
-    ; setting, default, val, description, info
-    this.Conf := Map()
-    this.AddToConf("VimEscNormal", 1, 1
-      , "ESC to enter the normal mode"
-      , "If checked, pressing ESC enters normal mode.")
-    this.AddToConf("VimEscNormalDirect", 1, 1
-      , "ESC to enter the normal mode directly even if converting in IME"
-      , "If checked, ESC enters normal mode even while IME is converting.`nIf not checked, ESC behaves as normal ESC while IME is converting.")
-    this.AddToConf("VimSendEscNormal", 0, 0
-      , "Send ESC by ESC at the normal mode"
-      , "If checked, a short ESC press sends ESC in normal mode.`nEnable ESC to enter normal mode first.")
-    this.AddToConf("VimLongEscNormal", 0, 0
-      , "Long press ESC to enter the normal mode"
-      , "If checked, short and long press behavior of ESC is swapped.`nEnable ESC to enter normal mode first.")
-    this.AddToConf("VimCtrlBracketToEsc", 1, 1
-      , "Ctrl-[ to ESC"
-      , "If checked, Ctrl-[ behaves as ESC.`nIf Ctrl-[ to normal mode is disabled, Ctrl-[ always sends ESC.`nIf both are checked, long press Ctrl-[ sends ESC.")
-    this.AddToConf("VimCtrlBracketNormal", 1, 1
-      , "Ctrl-[ to enter the normal mode"
-      , "If checked, pressing Ctrl-[ enters normal mode.")
-    this.AddToConf("VimCtrlBracketNormalDirect", 1, 1
-      , "Ctrl-[ to enter the normal mode directly even if converting in IME"
-      , "If checked, Ctrl-[ enters normal mode even while IME is converting.`nIf not checked, Ctrl-[ behaves as ESC while IME is converting.")
-    this.AddToConf("VimSendCtrlBracketNormal", 0, 0
-      , "Send Ctrl-[ by Ctrl-[ at the normal mode"
-      , "If checked, a short Ctrl-[ press sends Ctrl-[ in normal mode.`nEnable Ctrl-[ to enter normal mode first.")
-    this.AddToConf("VimLongCtrlBracketNormal", 0, 0
-      , "Long press Ctrl-[ to enter the normal mode"
-      , "If checked, short and long press behavior of Ctrl-[ is swapped.`nEnable Ctrl-[ to enter normal mode first.")
-    this.AddToConf("VimChangeCaretWidth", 0, 0
-      , "Change to thick text caret when in normal mode"
-      , "If checked, caret width changes by mode (thick in normal/visual, thin in insert).`nIt may not work in all applications and can briefly change window focus.")
-    this.AddToConf("VimRestoreIME", 1, 1
-      , "Restore IME status at entering the insert mode"
-      , "If checked, IME status is saved in insert mode and restored when returning to insert mode.")
-    this.AddToConf("VimJJ", 0, 0
-      , "JJ to enter the normal mode"
-      , "If checked, `jj` enters normal mode from insert mode.")
-    this.AddToConf("VimTwoLetter", "", ""
-      , "Two-letter to enter the normal mode"
-      , "Two-letter mappings to enter normal mode from insert mode.`nSet one pair per line.`nEach pair must be exactly two different letters.")
-    this.AddToConf("VimDisableUnused", 1, 1
-      , "Disable unused keys in the normal mode"
-      , "Disable level for unused keys outside insert mode:`n1: Do not disable unused keys`n2: Disable alphabets (+Shift) and symbols`n3: Disable all, including modified keys (e.g. Ctrl+Z)")
-    this.AddToConf("VimSetTitleMatchMode", "2", "2"
-      , "SetTitleMatchMode"
-      , "SetTitleMatchMode mode:`n1: Start with`n2: Contain`n3: Exact match`nRegEx: Regular expression")
-    this.AddToConf("VimSetTitleMatchModeFS", "Fast", "Fast"
-      , "SetTitleMatchMode"
-      , "SetTitleMatchMode speed:`nFast: Text is not detected for some edit controls`nSlow: Works for all windows, but slower")
-    this.AddToConf("VimIconCheckInterval", 1000, 1000
-      , "Icon check interval (ms)"
-      , "Interval (ms) to check vim_ahk status and update tray icon.`nIf set to 0, the original AHK icon is used.")
-    this.AddToConf("VimVerbose", 1, 1
-      , "Verbose level"
-      , "Verbose level:`n1: No output`n2: Minimum tooltip (mode only)`n3: Tooltip (all information)`n4: Debug message box (does not auto-close)")
-    this.AddToConf("VimAppList", "Allow List", "Allow List"
-      , "Application list usage"
-      , "Application list mode:`nAll: Enable vim_ahk on all applications (ignore the list)`nAllow List: Use list as allow list`nDeny List: Use list as deny list")
-    this.AddToConf("VimGroup", DefaultGroup, DefaultGroup
-      , "Application list"
-      , "Applications where vim_ahk is enabled.`nSet one application per line.`nEach line can be Window Title, Class, or Process.")
-
-    this.CheckBoxes := ["VimEscNormal", "VimEscNormalDirect", "VimSendEscNormal", "VimLongEscNormal", "VimCtrlBracketToEsc", "VimCtrlBracketNormal", "VimCtrlBracketNormalDirect", "VimSendCtrlBracketNormal", "VimLongCtrlBracketNormal", "VimRestoreIME", "VimJJ", "VimChangeCaretWidth"]
+    this.Conf := VimSettingSchema.Build(DefaultGroup, this.GroupDel)
 
     ; Initialize
     this.Initialize()
-  }
-
-  AddToConf(setting, default, val, description, info){
-    this.Conf[setting] :=  Map("default", default, "val", val, "description", description, "info", info)
-  }
-
-  SetConfDefault(){
-    for k, v in this.Conf {
-      v["val"] := v["default"]
-    }
   }
 
   SetExistValue(){
@@ -208,16 +74,30 @@ class VimAhk{
     return this.GetConf(Key, "val")
   }
 
-  GetDefault(Key){
-    return this.GetConf(Key, "default")
+  SetValues(Values){
+    NeedsReload := False
+    for Key, Value in Values {
+      Setting := this.Conf[Key]
+      if (Setting["val"] != Value && Setting["reload"]) {
+        NeedsReload := True
+      }
+      Setting["val"] := Value
+    }
+    return NeedsReload
   }
 
-  GetDescription(Key){
-    return this.GetConf(Key, "description")
-  }
-
-  GetInfo(Key){
-    return this.GetConf(Key, "info")
+  SetConfiguredGroups(){
+    for Key, Setting in this.Conf {
+      Group := Setting["group"]
+      if (Group == "") {
+        continue
+      }
+      Loop Parse, Setting["val"], this.GroupDel {
+        if (A_LoopField != "") {
+          GroupAdd(Group, A_LoopField)
+        }
+      }
+    }
   }
 
   SetGroup(){
@@ -242,6 +122,7 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
+    this.SetConfiguredGroups()
     this.VimMenu.SetMenu()
     this.Setup()
   }
@@ -265,16 +146,7 @@ class VimAhk{
                   , "ahk_exe q-dir.exe"     ; Q-dir
                   , "ahk_exe obsidian.exe"] ; Obsidian
 
-    DefaultGroup := ""
-    for i, v in DefaultList
-    {
-      if(DefaultGroup == ""){
-        DefaultGroup := v
-      }else{
-        DefaultGroup := DefaultGroup this.GroupDel v
-      }
-    }
-    Return DefaultGroup
+    return VimSettingSchema.Join(DefaultList, this.GroupDel)
   }
 
   IsVimGroup(){

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -11,6 +11,8 @@
 #Include %A_LineFile%\..\vim_ini.ahk
 #Include %A_LineFile%\..\vim_menu.ahk
 #Include %A_LineFile%\..\vim_move.ahk
+#Include %A_LineFile%\..\vim_setting_schema.ahk
+#Include %A_LineFile%\..\vim_setting_panel.ahk
 #Include %A_LineFile%\..\vim_setting.ahk
 #Include %A_LineFile%\..\vim_state.ahk
 #Include %A_LineFile%\..\vim_tooltip.ahk

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -50,6 +50,8 @@ class VimAhk{
     this.GroupDel := ","
     this.GroupN := 0
     this.GroupName := "VimGroup" this.GroupN
+    this.ConfiguredGroupN := 0
+    this.ConfiguredGroups := Map()
     DefaultGroup := this.SetDefaultActiveWindows()
     this.Conf := VimSettingSchema.Build(DefaultGroup, this.GroupDel)
 
@@ -75,29 +77,56 @@ class VimAhk{
   }
 
   SetValues(Values){
-    NeedsReload := False
+    this.ValidateLineBreakGroups(Values)
     for Key, Value in Values {
-      Setting := this.Conf[Key]
-      if (Setting["val"] != Value && Setting["reload"]) {
-        NeedsReload := True
-      }
-      Setting["val"] := Value
+      this.Conf[Key]["val"] := Value
     }
-    return NeedsReload
+  }
+
+  ValidateLineBreakGroups(Values){
+    ShiftApps := Map()
+    Loop Parse, Values["VimShiftEnter"], this.GroupDel {
+      if (A_LoopField != "") {
+        ShiftApps[StrLower(A_LoopField)] := A_LoopField
+      }
+    }
+
+    Conflicts := ""
+    Loop Parse, Values["VimCtrlEnter"], this.GroupDel {
+      if (A_LoopField != "" && ShiftApps.Has(StrLower(A_LoopField))) {
+        Conflicts .= (Conflicts == "" ? "" : "`n") A_LoopField
+      }
+    }
+
+    if (Conflicts != "") {
+      throw ValueError("Choose one line-break method for each application.`n"
+        . "The following entries appear in both Shift+Enter and Ctrl+Enter:`n`n"
+        . Conflicts)
+    }
   }
 
   SetConfiguredGroups(){
-    for Key, Setting in this.Conf {
+    this.ConfiguredGroupN++
+    Groups := Map()
+    for , Setting in this.Conf {
       Group := Setting["group"]
       if (Group == "") {
         continue
       }
+      GroupName := Group "_" this.ConfiguredGroupN
+      Groups[Group] := GroupName
       Loop Parse, Setting["val"], this.GroupDel {
         if (A_LoopField != "") {
-          GroupAdd(Group, A_LoopField)
+          GroupAdd(GroupName, A_LoopField)
         }
       }
     }
+    this.ConfiguredGroups := Groups
+  }
+
+  IsConfiguredGroup(Group){
+    return this.ConfiguredGroups.Has(Group)
+      and WinActive("ahk_group " this.ConfiguredGroups[Group])
   }
 
   SetGroup(){
@@ -113,6 +142,7 @@ class VimAhk{
   Setup(){
     SetTitleMatchMode(this.GetVal("VimSetTitleMatchMode"))
     SetTitleMatchMode(this.GetVal("VimSetTitleMatchModeFS"))
+    this.SetConfiguredGroups()
     this.State.SetStatusCheck()
     this.SetGroup()
     this.VimHotkey.Set()
@@ -122,7 +152,6 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
-    this.SetConfiguredGroups()
     this.VimMenu.SetMenu()
     this.Setup()
   }

--- a/lib/vim_gui.ahk
+++ b/lib/vim_gui.ahk
@@ -7,7 +7,7 @@ class VimGui{
     this.OKObj := ObjBindMethod(this, "OK")
   }
 
-  Hide(Obj){
+  Hide(Obj := 0){
     this.Vim.VimToolTip.RemoveToolTip()
     this.Obj.Hide()
   }
@@ -22,6 +22,7 @@ class VimGui{
     if(ToolTipText != ""){
       this.Vim.AddToolTip(Obj.Hwnd, ToolTipText)
     }
+    return Obj
   }
 
   MakeGui(){

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -19,7 +19,6 @@
     this.section := Section
 
     this.OpenIniDirObj := ObjBindMethod(this, "OpenIniDir")
-    this.OpenIniObj := ObjBindMethod(this, "OpenIni")
   }
 
   ReadIni(){
@@ -72,10 +71,5 @@
   OpenIniDir(Obj, Info){
     this.Vim.VimToolTip.RemoveToolTip()
     Run("explorer.exe " this.IniDir)
-  }
-
-  OpenIni(Obj, Info){
-    this.Vim.VimToolTip.RemoveToolTip()
-    Run("notepad.exe " this.Ini)
   }
 }

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -82,7 +82,7 @@
   }
 
   Zero(){
-    if WinActive("ahk_group VimDoubleHomeGroup"){
+    if this.Vim.IsConfiguredGroup("VimDoubleHomeGroup"){
       SendInput("{Home}")
     }
     SendInput("{Home}")
@@ -90,7 +90,7 @@
 
   Up(n:=1){
     Loop n {
-      if WinActive("ahk_group VimCtrlUpDownGroup"){
+      if this.Vim.IsConfiguredGroup("VimCtrlUpDownGroup"){
         SendInput("^{Up}")
       } else {
         SendInput("{Up}")
@@ -100,7 +100,7 @@
 
   Down(n:=1){
     Loop n {
-      if WinActive("ahk_group VimCtrlUpDownGroup"){
+      if this.Vim.IsConfiguredGroup("VimCtrlUpDownGroup"){
         SendInput("^{Down}")
       } else {
         SendInput("{Down}")
@@ -121,14 +121,14 @@
 
       ; 1 character
       if(Key == "h"){
-        if WinActive("ahk_group VimQdir"){
+        if this.Vim.IsConfiguredGroup("VimQdir"){
           SendInput("{BackSpace}")
         }
         else {
           SendInput("{Left}")
         }
       }else if(Key == "l"){
-        if WinActive("ahk_group VimQdir"){
+        if this.Vim.IsConfiguredGroup("VimQdir"){
           SendInput("{Enter}")
         }
         else {
@@ -145,13 +145,13 @@
         }
       }else if(Key == "^"){
         if(this.shift == 1){
-          if WinActive("ahk_group VimCaretMove"){
+          if this.Vim.IsConfiguredGroup("VimCaretMove"){
             SendInput("+{Home}+^{Right}+^{Left}")
           }else{
             SendInput("+{Home}")
           }
         }else{
-          if WinActive("ahk_group VimCaretMove"){
+          if this.Vim.IsConfiguredGroup("VimCaretMove"){
             SendInput("{Home}^{Right}^{Left}")
           }else{
             this.Zero()
@@ -202,7 +202,7 @@
     }else if(Key == "g"){
       SendInput("^{Home}")
     }else if(Key == "+g"){
-      if WinActive("ahk_group VimNonEditor"){
+      if this.Vim.IsConfiguredGroup("VimNonEditor"){
         SendInput("{End}")
       } else {
         SendInput("^{End}{Home}")
@@ -234,7 +234,7 @@
     }
     this.Down(this.Vim.State.n - 1)
     SendInput("{End}")
-    if not WinActive("ahk_group VimLBSelectGroup"){
+    if not this.Vim.IsConfiguredGroup("VimLBSelectGroup"){
       this.Move("l")
     }else{
       this.Move("")

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -69,18 +69,13 @@ class VimSetting Extends VimGui {
 
   StoreValues() {
     Values := this.Panel.NormalizedValues()
-    NeedsReload := this.Vim.SetValues(Values)
+    this.Vim.SetValues(Values)
     this.Vim.Ini.WriteIni()
-    return NeedsReload
   }
 
-  ActivateValues(NeedsReload, CloseWindow) {
+  ActivateValues(CloseWindow) {
     if CloseWindow {
       this.Hide()
-    }
-    if NeedsReload {
-      Reload()
-      return
     }
     this.Vim.Setup()
     this.Vim.VimToolTip.RemoveToolTip()
@@ -88,8 +83,8 @@ class VimSetting Extends VimGui {
 
   OK(Obj, Info) {
     try {
-      NeedsReload := this.StoreValues()
-      this.ActivateValues(NeedsReload, True)
+      this.StoreValues()
+      this.ActivateValues(True)
     } catch as ErrorInfo {
       MsgBox(ErrorInfo.Message, "Vim Ahk", "Iconx")
     }
@@ -97,8 +92,8 @@ class VimSetting Extends VimGui {
 
   Apply(Obj, Info) {
     try {
-      NeedsReload := this.StoreValues()
-      this.ActivateValues(NeedsReload, False)
+      this.StoreValues()
+      this.ActivateValues(False)
     } catch as ErrorInfo {
       MsgBox(ErrorInfo.Message, "Vim Ahk", "Iconx")
     }
@@ -135,10 +130,10 @@ class VimSetting Extends VimGui {
       if (Path == "") {
         return
       }
-      NeedsReload := this.StoreValues()
+      this.StoreValues()
       FileCopy(this.Vim.Ini.Ini, Path, True)
       MsgBox("Exported settings to:`n" Path, "Vim Ahk")
-      this.ActivateValues(NeedsReload, False)
+      this.ActivateValues(False)
     } catch as ErrorInfo {
       MsgBox("Failed to export: " ErrorInfo.Message, "Vim Ahk", "Iconx")
     }

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -20,27 +20,28 @@ class VimSetting Extends VimGui {
   MakeGui() {
     this.Obj.Opt("+Resize +MinSize520x380")
     this.Panel := VimSettingPanel(this.Obj, this.Vim.Conf, this.Vim.GroupDel)
-    this.ConfigLabel := this.Obj.Add("Text", "x12 y456 w100 h16", "Configuration file:")
-    this.ConfigPath := this.Obj.Add("Edit", "x120 y452 w540 h24 ReadOnly"
+    this.ConfigLabel := this.Obj.Add("Text", "x0 y0 w0 h0", "Configuration file:")
+    this.ConfigPath := this.Obj.Add("Edit", "x0 y0 w0 h0 ReadOnly"
       , this.Vim.Ini.Ini)
-    this.OpenFolderButton := this.AddClick("Button", "x668 y452 w84", "Open folder"
+    this.OpenFolderButton := this.AddClick("Button", "x0 y0 w0 h0", "Open folder"
       , this.Vim.Ini.OpenIniDirObj, "Open the current configuration directory")
 
-    this.ImportButton := this.AddClick("Button", "x12 y504 w80", "Import"
+    this.ImportButton := this.AddClick("Button", "x0 y0 w0 h0", "Import"
       , this.ImportObj, "Load settings from an INI file")
-    this.ExportButton := this.AddClick("Button", "x100 y504 w80", "Export"
+    this.ExportButton := this.AddClick("Button", "x0 y0 w0 h0", "Export"
       , this.ExportObj, "Save current settings to an INI file")
-    this.OKButton := this.AddClick("Button", "x408 y504 w80 Default", "OK"
+    this.OKButton := this.AddClick("Button", "x0 y0 w0 h0 Default", "OK"
       , this.OKObj, "Apply changes and close")
-    this.ApplyButton := this.AddClick("Button", "x496 y504 w80", "Apply"
+    this.ApplyButton := this.AddClick("Button", "x0 y0 w0 h0", "Apply"
       , this.ApplyObj, "Apply changes")
-    this.ResetButton := this.AddClick("Button", "x584 y504 w80", "Reset"
+    this.ResetButton := this.AddClick("Button", "x0 y0 w0 h0", "Reset"
       , this.ResetObj, "Show default values")
-    this.CancelButton := this.AddClick("Button", "x672 y504 w80", "Cancel"
+    this.CancelButton := this.AddClick("Button", "x0 y0 w0 h0", "Cancel"
       , this.CancelObj, "Discard staged changes and close")
 
     this.Obj.OnEvent("Size", this.ResizeObj)
     this.ResizeGui(this.Obj, 0, 764, 544)
+    this.Panel.RefreshList()
   }
 
   ResizeGui(GuiObj, MinMax, Width, Height) {

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -1,8 +1,10 @@
 #Include %A_LineFile%\..\vim_gui.ahk
+#Include %A_LineFile%\..\vim_ini.ahk
+#Include %A_LineFile%\..\vim_setting_panel.ahk
 
 
-class VimSetting Extends VimGui{
-  __New(Vim){
+class VimSetting Extends VimGui {
+  __New(Vim) {
     super.__New(Vim, "Vim Ahk Settings")
 
     this.ResetObj := ObjBindMethod(this, "Reset")
@@ -10,279 +12,135 @@ class VimSetting Extends VimGui{
     this.ApplyObj := ObjBindMethod(this, "Apply")
     this.ImportObj := ObjBindMethod(this, "ImportIni")
     this.ExportObj := ObjBindMethod(this, "ExportIni")
+    this.ResizeObj := ObjBindMethod(this, "ResizeGui")
   }
 
-  AddConf(ControlType, Key, Options, Text:="", V:=False){
-    if(ControlType == "Text"){
-      Text := this.Vim.GetDescription(Key)
-    }
-    if(V){
-      Options := Options " v" Key
-    }
-    Obj := this.Obj.Add(ControlType, Options, Text)
-    if(ControlType == "Text"){
-      ; Pseudo click event to show tooltip
-      Obj.OnEvent("Click", DoNothing(Obj, Info) => "")
-    }
-    this.Vim.AddToolTip(Obj.Hwnd, this.Vim.GetInfo(Key))
+  MakeGui() {
+    this.Obj.Opt("+Resize +MinSize680x480")
+    this.Panel := VimSettingPanel(this.Obj, this.Vim.Conf, this.Vim.GroupDel)
+    this.ConfigLabel := this.Obj.Add("Text", "x12 y456 w100 h16", "Configuration file:")
+    this.ConfigPath := this.Obj.Add("Edit", "x120 y452 w540 h24 ReadOnly"
+      , this.Vim.Ini.Ini)
+    this.OpenFolderButton := this.AddClick("Button", "x668 y452 w84", "Open folder"
+      , this.Vim.Ini.OpenIniDirObj, "Open the current configuration directory")
+
+    this.ImportButton := this.AddClick("Button", "x12 y504 w80", "Import"
+      , this.ImportObj, "Load settings from an INI file")
+    this.ExportButton := this.AddClick("Button", "x100 y504 w80", "Export"
+      , this.ExportObj, "Save current settings to an INI file")
+    this.OKButton := this.AddClick("Button", "x408 y504 w80 Default", "OK"
+      , this.OKObj, "Apply changes and close")
+    this.ApplyButton := this.AddClick("Button", "x496 y504 w80", "Apply"
+      , this.ApplyObj, "Apply changes")
+    this.ResetButton := this.AddClick("Button", "x584 y504 w80", "Reset"
+      , this.ResetObj, "Show default values")
+    this.CancelButton := this.AddClick("Button", "x672 y504 w80", "Cancel"
+      , this.CancelObj, "Discard staged changes and close")
+
+    this.Obj.OnEvent("Size", this.ResizeObj)
+    this.ResizeGui(this.Obj, 0, 764, 544)
   }
 
-  MakeGui(){
-    this.Obj.Opt("-Resize -MinimizeBox -MaximizeBox")
-    this.Tab := this.Obj.Add("Tab3", "X+0 Y+0 W480 H400", ["Keys", "Applications", "Status", "Configuration file"])
-
-    ; Tab 1: Keys
-    this.Tab.UseTab(1)
-    this.Obj.AddText("X+0 Y+0 Section", "")
-    for i, k in this.Vim.CheckBoxes {
-      x := (InStr(k, "Direct") or InStr(k, "Long") or InStr(k, "Send")) ? "30" : "10"
-      this.AddConf("Checkbox", k, "XS+" x " Y+6", this.Vim.GetDescription(k), True)
-      this.Obj[k].Value := this.Vim.GetVal(k)
+  ResizeGui(GuiObj, MinMax, Width, Height) {
+    if (MinMax == -1) {
+      return
     }
-    this.AddConf("Text", "VimTwoLetter", "XS+10 Y+15")
-    this.AddConf("Edit", "VimTwoLetter", "XS+10 Y+5 R4 W100 Multi", StrReplace(this.Vim.GetVal("VimTwoLetter"), this.Vim.GroupDel, "`n", 0, , -1), True)
-    this.AddConf("Text", "VimDisableUnused", "XS+10 Y+15")
-    this.AddConf("DDL", "VimDisableUnused", "X+5 YP-4 W40 Choose" this.Vim.GetVal("VimDisableUnused"), [1, 2, 3], True)
+    FooterTop := Height - 92
+    this.Panel.Resize(Width, Height, FooterTop)
+    OpenFolderX := Width - 96
+    this.ConfigLabel.Move(12, FooterTop + 4, 100, 16)
+    this.ConfigPath.Move(120, FooterTop, OpenFolderX - 128, 24)
+    this.OpenFolderButton.Move(OpenFolderX, FooterTop, 84, 24)
 
-    ; Tab 2: Applications (Merged with Matching & Lists)
-    this.Tab.UseTab(2)
-    this.Obj.AddText("X+0 Y+0 Section", "")
-    ; (Disabled unused keys moved to Keys tab)
-    this.AddConf("Text", "VimSetTitleMatchMode", "XS+10 Y+10")
-    if(this.Vim.GetVal("VimSetTitleMatchMode") == "RegEx"){
-      matchmode := 4
-    }else{
-      matchmode := this.Vim.GetVal("VimSetTitleMatchMode")
-    }
-    this.AddConf("DDL","VimSetTitleMatchMode",  "X+5 YP-4 W60 Choose" matchmode, [1, 2, 3, "RegEx"], True)
-    if(this.Vim.GetVal("VimSetTitleMatchModeFS") == "Fast"){
-      matchmodefs := 1
-    }else{
-      matchmodefs := 2
-    }
-    this.AddConf("DDL", "VimSetTitleMatchModeFS", "X+5 YP+0 W50 Choose" matchmodefs, ["Fast", "Slow"], True)
-
-    ; Applications specific
-    this.AddConf("Text", "VimAppList", "XS+10 Y+15")
-    if(this.Vim.GetVal("VimAppList") == "All"){
-      matchapplist := 1
-    }else if(this.Vim.GetVal("VimAppList") == "Allow List"){
-      matchapplist := 2
-    }else{
-      matchapplist := 3
-    }
-    this.AddConf("DDL", "VimAppList", "X+5 YP-4 W100 Choose" matchapplist, ["All", "Allow List", "Deny List"], True)
-    this.AddConf("Text", "VimGroup", "XS+10 Y+5")
-    this.AddConf("Edit", "VimGroup", "XS+10 Y+5 R10 W300 Multi", StrReplace(this.Vim.GetVal("VimGroup"), this.Vim.GroupDel, "`n", 0, , -1), True)
-
-    ; Tab 3: Status
-    this.Tab.UseTab(3)
-    this.Obj.AddText("X+0 Y+0 Section", "")
-    this.AddConf("Text", "VimIconCheckInterval", "XS+10 Y+10")
-    this.AddConf("Edit", "VimIconCheckInterval", "X+5 YP-4 W70")
-    this.AddConf("UpDown", "VimIconCheckInterval", "Range0-1000000", this.Vim.GetVal("VimIconCheckInterval"), True)
-    this.AddConf("Text", "VimVerbose", "XS+10 Y+10")
-    this.AddConf("DDL", "VimVerbose", "X+5 YP-4 W30 Choose" this.Vim.GetVal("VimVerbose"), [1, 2, 3, 4], True)
-
-    ; Tab 4: Configuration file
-    this.Tab.UseTab(4)
-    this.Obj.AddText("X+0 Y+0 Section", "")
-    SplitPath(this.Vim.Ini.Ini, &fileName, &iniDir)
-    this.Obj.AddText("XS+10 Y+10", "Current configuration directory:")
-    this.AddClick("Text", "XS+10 cBlue", iniDir, this.Vim.Ini.OpenIniDirObj)
-    this.Obj.AddText("XS+10 Y+10", "Current configuration file:")
-    this.AddClick("Text", "XS+10 cBlue", fileName, this.Vim.Ini.OpenIniObj)
-    this.AddClick("Button", "XS+10 Y+10 W120", "Import", this.ImportObj, "Load settings from an INI file")
-    this.AddClick("Button", "X+10 W120", "Export", this.ExportObj, "Save current settings to an INI file")
-
-    ; End tabs; add help and buttons below the tab
-    this.Tab.UseTab()
-
-    ; Add contents below the tab
-    this.Tab.GetPos(&tabX, &tabY, &tabW, &tabH)
-    underTab := tabY + tabH + 10
-
-    ;; Create help controls and measure
-    this.Obj.AddText("X15 Y" underTab, "Check")
-    this.Obj.SetFont("Underline")
-    this.AddClick("Text", "X+5 cBlue", "HELP", this.Vim.about.OpenHomepageObj, this.Vim.About.Homepage)
-    this.Obj.SetFont("Norm")
-    this.Obj.AddText("X+5", "for further information.")
-
-    this.AddClick("Button", "X15 W100 Y+10 Default", "OK", this.OKObj, "Apply changes and close")
-    this.AddClick("Button", "X+10 W100", "Apply", this.ApplyObj, "Apply changes without closing")
-    this.AddClick("Button", "X+10 W100", "Reset", this.ResetObj, "Reset to the default values")
-    this.AddClick("Button", "X+10 W100", "Cancel", this.CancelObj, "Discard changes and close")
+    ButtonY := Height - 36
+    this.ImportButton.Move(12, ButtonY, 80)
+    this.ExportButton.Move(100, ButtonY, 80)
+    RightX := Width - 356
+    this.OKButton.Move(RightX, ButtonY, 80)
+    this.ApplyButton.Move(RightX + 88, ButtonY, 80)
+    this.ResetButton.Move(RightX + 176, ButtonY, 80)
+    this.CancelButton.Move(RightX + 264, ButtonY, 80)
   }
 
-  UpdateGui(){
-    this.UpdateGuiValue()
+  UpdateGui() {
+    this.Panel.LoadValues(VimSettingSchema.Values(this.Vim.Conf))
+    this.ConfigPath.Text := this.Vim.Ini.Ini
   }
 
-  UpdateGuiValue(){
-    for i, k in this.Vim.CheckBoxes {
-      this.Obj[k].Value := this.Vim.GetVal(k)
-    }
-    this.Obj["VimTwoLetter"].Value := StrReplace(this.Vim.GetVal("VimTwoLetter"), this.Vim.GroupDel, "`n", 0, , -1)
-    this.Obj["VimDisableUnused"].Value := this.Vim.GetVal("VimDisableUnused")
-    this.Obj["VimIconCheckInterval"].Value := this.Vim.GetVal("VimIconCheckInterval")
-    if(this.Vim.GetVal("VimSetTitleMatchMode") == "RegEx"){
-      matchmode := 4
-    }else{
-      matchmode := this.Vim.GetVal("VimSetTitleMatchMode")
-    }
-    this.Obj["VimSetTitleMatchMode"].Value := matchmode
-    if(this.Vim.GetVal("VimSetTitleMatchModeFS") == "Fast"){
-      matchmodefs := 1
-    }else{
-      matchmodefs := 2
-    }
-    this.Obj["VimSetTitleMatchModeFS"].Value := matchmodefs
-    this.Obj["VimVerbose"].Value := this.Vim.GetVal("VimVerbose")
-    if(this.Vim.GetVal("VimAppList") == "All"){
-      matchapplist := 1
-    }else if(this.Vim.GetVal("VimAppList") == "Allow List"){
-      matchapplist := 2
-    }else{
-      matchapplist := 3
-    }
-    this.Obj["VimAppList"].Value := matchapplist
-    this.Obj["VimGroup"].Value := StrReplace(this.Vim.GetVal("VimGroup"), this.Vim.GroupDel, "`n", 0, , -1)
-  }
-
-  VimV2Conf(){
-    for k, v in this.Vim.Conf {
-      if(k == "VimGroup" || k == "VimTwoLetter"){
-        v["val"] := this.VimParseList(this.Obj[k].Value)
-      }else if(k == "VimSetTitleMatchMode" && this.Obj[k].Value == 4){
-        v["val"] := "RegEx"
-      }else if(k == "VimSetTitleMatchModeFS"){
-        if(this.Obj[k].Value == 1){
-          v["val"] := "Fast"
-        }else{
-          v["val"] := "Slow"
-        }
-      }else if(k == "VimAppList"){
-        if(this.Obj[k].Value == 1){
-          v["val"] := "All"
-        }else if(this.Obj[k].Value == 2){
-          v["val"] := "Allow List"
-        }else{
-          v["val"] := "Deny List"
-        }
-      }else{
-        v["val"] := this.Obj[k].Value
-      }
-    }
-  }
-
-  VimParseList(List){
-    result := ""
-    tmpArray := []
-    Loop Parse, List, "`n" {
-      if(! tmpArray.Has(A_LoopField)){
-        tmpArray.push(A_LoopField)
-        if(result == ""){
-          result := A_LoopField
-        }else{
-          result := result this.Vim.GroupDel A_LoopField
-        }
-      }
-    }
-    return result
-  }
-
-  OK(Obj, Info){
-    this.Obj.Submit()
-    this.VimV2Conf()
-    this.Vim.Setup()
+  StoreValues() {
+    Values := this.Panel.NormalizedValues()
+    NeedsReload := this.Vim.SetValues(Values)
     this.Vim.Ini.WriteIni()
-    this.Hide(Obj)
+    return NeedsReload
   }
 
-  Apply(Obj, Info){
-    this.Obj.Submit(false)
-    this.VimV2Conf()
+  ActivateValues(NeedsReload, CloseWindow) {
+    if CloseWindow {
+      this.Hide()
+    }
+    if NeedsReload {
+      Reload()
+      return
+    }
     this.Vim.Setup()
-    this.Vim.Ini.WriteIni()
     this.Vim.VimToolTip.RemoveToolTip()
   }
 
-  Cancel(Obj, Info){
-    this.Hide(Obj)
-  }
-
-  Reset(Obj, Info){
-    this.Vim.SetConfDefault()
-    this.UpdateGuiValue()
-  }
-
-  ImportIni(Obj, Info){
+  OK(Obj, Info) {
     try {
-      path := FileSelect("", "", "Import INI (staged; Apply to confirm)", "INI (*.ini)")
-      if (path == "")
-        return
-      ; Read selected INI into a temporary conf map without touching runtime conf
-      tmpConf := Map()
-      for k, v in this.Vim.Conf {
-        tmpConf[k] := Map("default", v["default"], "val", v["val"], "description", v["description"], "info", v["info"])
-      }
-      SplitPath(path, &fileName, &dir)
-      tmpVim := {Conf: tmpConf, GroupDel: this.Vim.GroupDel}
-      tmpIni := VimIni(tmpVim, dir, fileName)
-      tmpIni.ReadIni()
-
-      ; Update GUI controls from tmpConf only
-      ; CheckBoxes
-      for i, k in this.Vim.CheckBoxes {
-        if this.Obj.HasProp(k) && tmpConf.Has(k)
-          this.Obj[k].Value := tmpConf[k]["val"]
-      }
-      ; Text/DDL fields with conversions
-      if this.Obj.HasProp("VimTwoLetter")
-        this.Obj["VimTwoLetter"].Value := StrReplace(tmpConf["VimTwoLetter"]["val"], this.Vim.GroupDel, "`n", 0, , -1)
-      if this.Obj.HasProp("VimDisableUnused")
-        this.Obj["VimDisableUnused"].Value := tmpConf["VimDisableUnused"]["val"]
-      if this.Obj.HasProp("VimIconCheckInterval")
-        this.Obj["VimIconCheckInterval"].Value := tmpConf["VimIconCheckInterval"]["val"]
-      ; Title match mode
-      if this.Obj.HasProp("VimSetTitleMatchMode") {
-        matchmode := tmpConf["VimSetTitleMatchMode"]["val"]
-        this.Obj["VimSetTitleMatchMode"].Value := (matchmode == "RegEx") ? 4 : matchmode
-      }
-      if this.Obj.HasProp("VimSetTitleMatchModeFS") {
-        matchmodefs := tmpConf["VimSetTitleMatchModeFS"]["val"]
-        this.Obj["VimSetTitleMatchModeFS"].Value := (matchmodefs == "Fast") ? 1 : 2
-      }
-      if this.Obj.HasProp("VimVerbose")
-        this.Obj["VimVerbose"].Value := tmpConf["VimVerbose"]["val"]
-      if this.Obj.HasProp("VimAppList") {
-        ap := tmpConf["VimAppList"]["val"]
-        this.Obj["VimAppList"].Value := (ap == "All") ? 1 : (ap == "Allow List") ? 2 : 3
-      }
-      if this.Obj.HasProp("VimGroup")
-        this.Obj["VimGroup"].Value := StrReplace(tmpConf["VimGroup"]["val"], this.Vim.GroupDel, "`n", 0, , -1)
-
-      ; Do not write to the main INI nor apply runtime yet — waits for Apply
-      MsgBox("Imported settings staged from:`n" path "`nClick Apply to apply them.", "Vim Ahk")
-    } catch as e {
-      MsgBox("Failed to import: " e.Message, "Vim Ahk", "Iconx")
+      NeedsReload := this.StoreValues()
+      this.ActivateValues(NeedsReload, True)
+    } catch as ErrorInfo {
+      MsgBox(ErrorInfo.Message, "Vim Ahk", "Iconx")
     }
   }
 
-  ExportIni(Obj, Info){
+  Apply(Obj, Info) {
     try {
-      path := FileSelect("S", "", "Export INI", "INI (*.ini)")
-      if (path == "")
+      NeedsReload := this.StoreValues()
+      this.ActivateValues(NeedsReload, False)
+    } catch as ErrorInfo {
+      MsgBox(ErrorInfo.Message, "Vim Ahk", "Iconx")
+    }
+  }
+
+  Cancel(Obj, Info) {
+    this.Hide(Obj)
+  }
+
+  Reset(Obj, Info) {
+    this.Panel.LoadDefaults()
+  }
+
+  ImportIni(Obj, Info) {
+    try {
+      Path := FileSelect("", "", "Import INI (staged; Apply to confirm)", "INI (*.ini)")
+      if (Path == "") {
         return
-      ; Ensure current settings are saved before export
-      this.Obj.Submit(false)
-      this.VimV2Conf()
-      this.Vim.Ini.WriteIni()
-      FileCopy(this.Vim.Ini.Ini, path, true)
-      MsgBox("Exported settings to: `n" path, "Vim Ahk")
-    } catch as e {
-      MsgBox("Failed to export: " e.Message, "Vim Ahk", "Iconx")
+      }
+      TempConf := VimSettingSchema.Copy(this.Vim.Conf)
+      SplitPath(Path, &FileName, &Directory)
+      TempVim := {Conf: TempConf, GroupDel: this.Vim.GroupDel}
+      VimIni(TempVim, Directory, FileName).ReadIni()
+      this.Panel.LoadValues(VimSettingSchema.Values(TempConf))
+      MsgBox("Imported settings staged from:`n" Path "`nClick Apply to apply them.", "Vim Ahk")
+    } catch as ErrorInfo {
+      MsgBox("Failed to import: " ErrorInfo.Message, "Vim Ahk", "Iconx")
+    }
+  }
+
+  ExportIni(Obj, Info) {
+    try {
+      Path := FileSelect("S", "", "Export INI", "INI (*.ini)")
+      if (Path == "") {
+        return
+      }
+      NeedsReload := this.StoreValues()
+      FileCopy(this.Vim.Ini.Ini, Path, True)
+      MsgBox("Exported settings to:`n" Path, "Vim Ahk")
+      this.ActivateValues(NeedsReload, False)
+    } catch as ErrorInfo {
+      MsgBox("Failed to export: " ErrorInfo.Message, "Vim Ahk", "Iconx")
     }
   }
 }

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -4,8 +4,6 @@
 
 
 class VimSetting Extends VimGui {
-  static NarrowWidth := 680
-
   __New(Vim) {
     super.__New(Vim, "Vim Ahk Settings")
 
@@ -14,58 +12,54 @@ class VimSetting Extends VimGui {
     this.ApplyObj := ObjBindMethod(this, "Apply")
     this.ImportObj := ObjBindMethod(this, "ImportIni")
     this.ExportObj := ObjBindMethod(this, "ExportIni")
-    this.ResizeObj := ObjBindMethod(this, "ResizeGui")
   }
 
   MakeGui() {
-    this.Obj.Opt("+Resize +MinSize520x380")
-    this.Panel := VimSettingPanel(this.Obj, this.Vim.Conf, this.Vim.GroupDel)
-    this.ConfigLabel := this.Obj.Add("Text", "x0 y0 w0 h0", "Configuration file:")
-    this.ConfigPath := this.Obj.Add("Edit", "x0 y0 w0 h0 ReadOnly"
-      , this.Vim.Ini.Ini)
-    this.OpenFolderButton := this.AddClick("Button", "x0 y0 w0 h0", "Open folder"
-      , this.Vim.Ini.OpenIniDirObj, "Open the current configuration directory")
-
-    this.ImportButton := this.AddClick("Button", "x0 y0 w0 h0", "Import"
-      , this.ImportObj, "Load settings from an INI file")
-    this.ExportButton := this.AddClick("Button", "x0 y0 w0 h0", "Export"
-      , this.ExportObj, "Save current settings to an INI file")
-    this.OKButton := this.AddClick("Button", "x0 y0 w0 h0 Default", "OK"
-      , this.OKObj, "Apply changes and close")
-    this.ApplyButton := this.AddClick("Button", "x0 y0 w0 h0", "Apply"
-      , this.ApplyObj, "Apply changes")
-    this.ResetButton := this.AddClick("Button", "x0 y0 w0 h0", "Reset"
-      , this.ResetObj, "Show default values")
-    this.CancelButton := this.AddClick("Button", "x0 y0 w0 h0", "Cancel"
-      , this.CancelObj, "Discard staged changes and close")
-
-    this.Obj.OnEvent("Size", this.ResizeObj)
-    this.ResizeGui(this.Obj, 0, 764, 544)
-    this.Panel.RefreshList()
+    this.Obj.Opt("-Resize -MinimizeBox -MaximizeBox")
+    this.Tab := this.Obj.Add("Tab3", "X+0 Y+0 W480 H400"
+      , ["Keys", "Applications", "Status", "Configuration file"])
+    this.Panel := VimSettingPanel(
+      this.Obj, this.Tab, this.Vim.Conf, this.Vim.GroupDel)
+    this.MakeConfigurationTab()
+    this.MakeFooter()
   }
 
-  ResizeGui(GuiObj, MinMax, Width, Height) {
-    if (MinMax == -1) {
-      return
-    }
-    Narrow := Width < VimSetting.NarrowWidth
-    FooterHeight := Narrow ? 108 : 92
-    FooterTop := Height - FooterHeight
-    this.Panel.Resize(Width, FooterTop, Narrow)
-    OpenFolderX := Width - 96
-    this.ConfigLabel.Move(12, FooterTop + 4, 100, 16)
-    this.ConfigPath.Move(120, FooterTop, OpenFolderX - 128, 24)
-    this.OpenFolderButton.Move(OpenFolderX, FooterTop, 84, 24)
+  MakeConfigurationTab() {
+    this.Tab.UseTab(4)
+    this.Obj.Add("Text", "X+0 Y+0 Section", "")
+    this.ConfigLabel := this.Obj.Add(
+      "Text", "XS+10 Y+10", "Current configuration file:")
+    this.ConfigPath := this.Obj.Add(
+      "Edit", "XS+10 Y+5 W430 ReadOnly", this.Vim.Ini.Ini)
+    this.OpenFolderButton := this.AddClick(
+      "Button", "XS+10 Y+12 W100", "Open folder"
+      , this.Vim.Ini.OpenIniDirObj, "Open the current configuration directory")
+    this.ImportButton := this.AddClick(
+      "Button", "X+10 W100", "Import", this.ImportObj
+      , "Load settings from an INI file")
+    this.ExportButton := this.AddClick(
+      "Button", "X+10 W100", "Export", this.ExportObj
+      , "Save current settings to an INI file")
+    this.Tab.UseTab()
+  }
 
-    ActionY := Height - 36
-    UtilityY := Narrow ? Height - 68 : ActionY
-    this.ImportButton.Move(12, UtilityY, 80, 24)
-    this.ExportButton.Move(100, UtilityY, 80, 24)
-    RightX := Width - 356
-    this.OKButton.Move(RightX, ActionY, 80, 24)
-    this.ApplyButton.Move(RightX + 88, ActionY, 80, 24)
-    this.ResetButton.Move(RightX + 176, ActionY, 80, 24)
-    this.CancelButton.Move(RightX + 264, ActionY, 80, 24)
+  MakeFooter() {
+    this.Tab.GetPos(&TabX, &TabY, &TabWidth, &TabHeight)
+    FooterY := TabY + TabHeight + 10
+    ButtonWidth := 100
+    ButtonGap := 10
+    this.OKButton := this.AddClick(
+      "Button", "X" TabX " Y" FooterY " W" ButtonWidth " Default"
+      , "OK", this.OKObj, "Apply changes and close")
+    this.ApplyButton := this.AddClick(
+      "Button", "X+" ButtonGap " W" ButtonWidth
+      , "Apply", this.ApplyObj, "Apply changes")
+    this.ResetButton := this.AddClick(
+      "Button", "X+" ButtonGap " W" ButtonWidth
+      , "Reset", this.ResetObj, "Show default values")
+    this.CancelButton := this.AddClick(
+      "Button", "X+" ButtonGap " W" ButtonWidth
+      , "Cancel", this.CancelObj, "Discard staged changes and close")
   }
 
   UpdateGui() {

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -4,6 +4,8 @@
 
 
 class VimSetting Extends VimGui {
+  static NarrowWidth := 680
+
   __New(Vim) {
     super.__New(Vim, "Vim Ahk Settings")
 
@@ -16,7 +18,7 @@ class VimSetting Extends VimGui {
   }
 
   MakeGui() {
-    this.Obj.Opt("+Resize +MinSize680x480")
+    this.Obj.Opt("+Resize +MinSize520x380")
     this.Panel := VimSettingPanel(this.Obj, this.Vim.Conf, this.Vim.GroupDel)
     this.ConfigLabel := this.Obj.Add("Text", "x12 y456 w100 h16", "Configuration file:")
     this.ConfigPath := this.Obj.Add("Edit", "x120 y452 w540 h24 ReadOnly"
@@ -45,21 +47,24 @@ class VimSetting Extends VimGui {
     if (MinMax == -1) {
       return
     }
-    FooterTop := Height - 92
-    this.Panel.Resize(Width, Height, FooterTop)
+    Narrow := Width < VimSetting.NarrowWidth
+    FooterHeight := Narrow ? 108 : 92
+    FooterTop := Height - FooterHeight
+    this.Panel.Resize(Width, FooterTop, Narrow)
     OpenFolderX := Width - 96
     this.ConfigLabel.Move(12, FooterTop + 4, 100, 16)
     this.ConfigPath.Move(120, FooterTop, OpenFolderX - 128, 24)
     this.OpenFolderButton.Move(OpenFolderX, FooterTop, 84, 24)
 
-    ButtonY := Height - 36
-    this.ImportButton.Move(12, ButtonY, 80)
-    this.ExportButton.Move(100, ButtonY, 80)
+    ActionY := Height - 36
+    UtilityY := Narrow ? Height - 68 : ActionY
+    this.ImportButton.Move(12, UtilityY, 80, 24)
+    this.ExportButton.Move(100, UtilityY, 80, 24)
     RightX := Width - 356
-    this.OKButton.Move(RightX, ButtonY, 80)
-    this.ApplyButton.Move(RightX + 88, ButtonY, 80)
-    this.ResetButton.Move(RightX + 176, ButtonY, 80)
-    this.CancelButton.Move(RightX + 264, ButtonY, 80)
+    this.OKButton.Move(RightX, ActionY, 80, 24)
+    this.ApplyButton.Move(RightX + 88, ActionY, 80, 24)
+    this.ResetButton.Move(RightX + 176, ActionY, 80, 24)
+    this.CancelButton.Move(RightX + 264, ActionY, 80, 24)
   }
 
   UpdateGui() {

--- a/lib/vim_setting_panel.ahk
+++ b/lib/vim_setting_panel.ahk
@@ -1,0 +1,217 @@
+#Include %A_LineFile%\..\vim_setting_schema.ahk
+
+
+class VimSettingPanel {
+  __New(GuiObj, Schema, Delimiter) {
+    this.Gui := GuiObj
+    this.Schema := Schema
+    this.Delimiter := Delimiter
+    this.Values := VimSettingSchema.Values(Schema)
+    this.RowKeys := Map()
+    this.Categories := []
+    this.CurrentKey := ""
+    this.ListWidth := 554
+
+    this.SearchLabel := this.Gui.Add("Text", "x12 y15 w48", "Search:")
+    this.Search := this.Gui.Add("Edit", "x64 y12 w684")
+    this.Category := this.Gui.Add("ListBox", "x12 y46 w170 h380")
+    this.List := this.Gui.Add("ListView", "x194 y46 w554 h240 -Multi", ["Setting", "Value"])
+    this.Name := this.Gui.Add("Text", "x194 y298 w554 h22")
+    this.Info := this.Gui.Add("Text", "x194 y324 w554 h52")
+    this.Boolean := this.Gui.Add("CheckBox", "x194 y386 w554", "Enabled")
+    this.Choice := this.Gui.Add("DropDownList", "x194 y386 w300")
+    this.Text := this.Gui.Add("Edit", "x194 y386 w554")
+    this.ListText := this.Gui.Add("Edit", "x194 y386 w554 h70 Multi VScroll WantTab")
+
+    this.Search.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
+    this.Category.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
+    this.List.OnEvent("ItemSelect", ObjBindMethod(this, "ItemSelected"))
+    this.Boolean.OnEvent("Click", ObjBindMethod(this, "EditorChanged"))
+    this.Choice.OnEvent("Change", ObjBindMethod(this, "EditorChanged"))
+    this.Text.OnEvent("Change", ObjBindMethod(this, "EditorChanged"))
+    this.ListText.OnEvent("Change", ObjBindMethod(this, "EditorChanged"))
+
+    this.LoadCategories()
+    this.HideEditors()
+    this.RefreshList()
+  }
+
+  LoadCategories() {
+    Seen := Map()
+    this.Categories := ["All"]
+    for , Setting in this.Schema {
+      Category := Setting["category"]
+      if !Seen.Has(Category) {
+        Seen[Category] := True
+        this.Categories.Push(Category)
+      }
+    }
+    this.Category.Delete()
+    this.Category.Add(this.Categories)
+    this.Category.Choose(1)
+  }
+
+  FilterChanged(Control, Info) {
+    this.RefreshList()
+  }
+
+  RefreshList() {
+    PreferredKey := this.CurrentKey
+    CategoryIndex := this.Category.Value
+    Category := CategoryIndex ? this.Categories[CategoryIndex] : "All"
+    Query := StrLower(Trim(this.Search.Text))
+    this.List.Delete()
+    this.RowKeys := Map()
+    SelectedRow := 0
+    for Key, Setting in this.Schema {
+      if (Category != "All" && Setting["category"] != Category) {
+        continue
+      }
+      SearchText := StrLower(Key " " Setting["description"] " " Setting["info"])
+      if (Query != "" && !InStr(SearchText, Query)) {
+        continue
+      }
+      Row := this.List.Add("", Setting["description"]
+        , VimSettingSchema.Summary(Setting, this.Values[Key], this.Delimiter))
+      this.RowKeys[Row] := Key
+      if (Key == PreferredKey) {
+        SelectedRow := Row
+      }
+    }
+    this.ResizeColumns()
+    if (!SelectedRow && this.RowKeys.Count) {
+      SelectedRow := 1
+    }
+    if SelectedRow {
+      this.List.Modify(SelectedRow, "Select Focus Vis")
+      this.ShowEditor(this.RowKeys[SelectedRow])
+    } else {
+      this.CurrentKey := ""
+      this.Name.Text := ""
+      this.Info.Text := ""
+      this.HideEditors()
+    }
+  }
+
+  ItemSelected(Control, Row, Selected) {
+    if (Selected && this.RowKeys.Has(Row)) {
+      this.ShowEditor(this.RowKeys[Row])
+    }
+  }
+
+  ShowEditor(Key) {
+    this.CurrentKey := Key
+    Setting := this.Schema[Key]
+    this.Name.Text := Setting["description"]
+    this.Info.Text := Setting["info"]
+    this.HideEditors()
+    Kind := Setting["kind"]
+    if (Kind == "boolean") {
+      this.Boolean.Value := this.Values[Key]
+      this.Boolean.Visible := True
+    } else if (Kind == "choice") {
+      this.Choice.Delete()
+      this.Choice.Add(Setting["choices"])
+      ChoiceIndex := 0
+      for Index, Choice in Setting["choices"] {
+        if (Choice == this.Values[Key]) {
+          ChoiceIndex := Index
+          break
+        }
+      }
+      this.Choice.Choose(ChoiceIndex)
+      this.Choice.Visible := True
+    } else if (Kind == "list") {
+      this.ListText.Text := VimSettingSchema.ToEditor(Setting, this.Values[Key], this.Delimiter)
+      this.ListText.Visible := True
+    } else {
+      this.Text.Text := this.Values[Key]
+      this.Text.Visible := True
+    }
+  }
+
+  HideEditors() {
+    this.Boolean.Visible := False
+    this.Choice.Visible := False
+    this.Text.Visible := False
+    this.ListText.Visible := False
+  }
+
+  EditorChanged(Control, Info) {
+    if (this.CurrentKey == "") {
+      return
+    }
+    Setting := this.Schema[this.CurrentKey]
+    Kind := Setting["kind"]
+    if (Kind == "boolean") {
+      Value := this.Boolean.Value
+    } else if (Kind == "choice") {
+      Value := this.Choice.Text
+    } else if (Kind == "list") {
+      Value := VimSettingSchema.NormalizeList(this.ListText.Text, this.Delimiter)
+    } else {
+      Value := this.Text.Text
+    }
+    this.Values[this.CurrentKey] := Value
+    for Row, Key in this.RowKeys {
+      if (Key == this.CurrentKey) {
+        this.List.Modify(Row, "Col2", VimSettingSchema.Summary(Setting, Value, this.Delimiter))
+        break
+      }
+    }
+  }
+
+  LoadValues(Values) {
+    for Key in this.Schema {
+      if Values.Has(Key) {
+        this.Values[Key] := Values[Key]
+      }
+    }
+    this.RefreshList()
+  }
+
+  LoadDefaults() {
+    this.LoadValues(VimSettingSchema.Values(this.Schema, True))
+  }
+
+  NormalizedValues() {
+    Values := Map()
+    for Key, Setting in this.Schema {
+      Values[Key] := VimSettingSchema.Normalize(Setting, this.Values[Key], this.Delimiter)
+    }
+    return Values
+  }
+
+  ResizeColumns() {
+    this.List.ModifyCol(1, Max(180, this.ListWidth - 120))
+    this.List.ModifyCol(2, 110)
+  }
+
+  Resize(Width, Height, FooterTop) {
+    Margin := 12
+    LeftWidth := 170
+    Gap := 12
+    RightX := Margin + LeftWidth + Gap
+    RightWidth := Max(300, Width - RightX - Margin)
+    ContentTop := 46
+    ContentHeight := Max(280, FooterTop - ContentTop - Gap)
+    ListHeight := Max(150, Floor(ContentHeight * 0.55))
+    NameY := ContentTop + ListHeight + 12
+    InfoY := NameY + 24
+    EditorY := InfoY + 58
+    EditorHeight := Max(24, FooterTop - EditorY - Gap)
+
+    this.SearchLabel.Move(Margin, Margin + 3, 48, 20)
+    this.Search.Move(Margin + 52, Margin, Width - Margin * 2 - 52)
+    this.Category.Move(Margin, ContentTop, LeftWidth, ContentHeight)
+    this.List.Move(RightX, ContentTop, RightWidth, ListHeight)
+    this.ListWidth := RightWidth
+    this.Name.Move(RightX, NameY, RightWidth, 22)
+    this.Info.Move(RightX, InfoY, RightWidth, 52)
+    this.Boolean.Move(RightX, EditorY, RightWidth, 24)
+    this.Choice.Move(RightX, EditorY, Min(320, RightWidth), 24)
+    this.Text.Move(RightX, EditorY, RightWidth, 24)
+    this.ListText.Move(RightX, EditorY, RightWidth, EditorHeight)
+    this.ResizeColumns()
+  }
+}

--- a/lib/vim_setting_panel.ahk
+++ b/lib/vim_setting_panel.ahk
@@ -10,21 +10,16 @@ class VimSettingPanel {
     this.RowKeys := Map()
     this.Categories := []
     this.CurrentKey := ""
-    this.ListWidth := 554
-    this.RightX := 194
-    this.RightWidth := 554
-    this.DetailsTop := 298
-    this.DetailsBottom := 464
 
-    this.SearchLabel := this.Gui.Add("Text", "x12 y15 w48", "Search:")
-    this.Search := this.Gui.Add("Edit", "x64 y12 w684")
-    this.Category := this.Gui.Add("ListBox", "x12 y46 w170 h380")
-    this.List := this.Gui.Add("ListView", "x194 y46 w554 h240 -Multi", ["Setting", "Value"])
-    this.Details := this.Gui.Add("Edit", "x194 y298 w554 h134 ReadOnly Multi VScroll")
-    this.Boolean := this.Gui.Add("CheckBox", "x194 y440 w554", "Enabled")
-    this.Choice := this.Gui.Add("DropDownList", "x194 y440 w300")
-    this.Text := this.Gui.Add("Edit", "x194 y440 w554")
-    this.ListText := this.Gui.Add("Edit", "x194 y394 w554 h70 Multi VScroll WantTab")
+    this.SearchLabel := this.Gui.Add("Text", "x0 y0 w0 h0", "Search:")
+    this.Search := this.Gui.Add("Edit", "x0 y0 w0 h0")
+    this.Category := this.Gui.Add("ListBox", "x0 y0 w0 h0")
+    this.List := this.Gui.Add("ListView", "x0 y0 w0 h0 -Multi", ["Setting", "Value"])
+    this.Details := this.Gui.Add("Edit", "x0 y0 w0 h0 ReadOnly Multi VScroll")
+    this.Boolean := this.Gui.Add("CheckBox", "x0 y0 w0 h0", "Enabled")
+    this.Choice := this.Gui.Add("DropDownList", "x0 y0 w0 h0")
+    this.Text := this.Gui.Add("Edit", "x0 y0 w0 h0")
+    this.ListText := this.Gui.Add("Edit", "x0 y0 w0 h0 Multi VScroll WantTab")
 
     this.Search.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
     this.Category.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
@@ -36,7 +31,6 @@ class VimSettingPanel {
 
     this.LoadCategories()
     this.HideEditors()
-    this.RefreshList()
   }
 
   LoadCategories() {
@@ -183,11 +177,7 @@ class VimSettingPanel {
   }
 
   NormalizedValues() {
-    Values := Map()
-    for Key, Setting in this.Schema {
-      Values[Key] := VimSettingSchema.Normalize(Setting, this.Values[Key], this.Delimiter)
-    }
-    return Values
+    return VimSettingSchema.NormalizeValues(this.Schema, this.Values, this.Delimiter)
   }
 
   ResizeColumns() {

--- a/lib/vim_setting_panel.ahk
+++ b/lib/vim_setting_panel.ahk
@@ -11,17 +11,21 @@ class VimSettingPanel {
     this.Categories := []
     this.CurrentKey := ""
     this.ListWidth := 554
+    this.RightX := 194
+    this.RightWidth := 554
+    this.DetailsTop := 298
+    this.DetailsBottom := 464
 
     this.SearchLabel := this.Gui.Add("Text", "x12 y15 w48", "Search:")
     this.Search := this.Gui.Add("Edit", "x64 y12 w684")
     this.Category := this.Gui.Add("ListBox", "x12 y46 w170 h380")
     this.List := this.Gui.Add("ListView", "x194 y46 w554 h240 -Multi", ["Setting", "Value"])
     this.Name := this.Gui.Add("Text", "x194 y298 w554 h22")
-    this.Info := this.Gui.Add("Text", "x194 y324 w554 h52")
-    this.Boolean := this.Gui.Add("CheckBox", "x194 y386 w554", "Enabled")
-    this.Choice := this.Gui.Add("DropDownList", "x194 y386 w300")
-    this.Text := this.Gui.Add("Edit", "x194 y386 w554")
-    this.ListText := this.Gui.Add("Edit", "x194 y386 w554 h70 Multi VScroll WantTab")
+    this.Info := this.Gui.Add("Text", "x194 y322 w554 h110")
+    this.Boolean := this.Gui.Add("CheckBox", "x194 y440 w554", "Enabled")
+    this.Choice := this.Gui.Add("DropDownList", "x194 y440 w300")
+    this.Text := this.Gui.Add("Edit", "x194 y440 w554")
+    this.ListText := this.Gui.Add("Edit", "x194 y394 w554 h70 Multi VScroll WantTab")
 
     this.Search.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
     this.Category.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
@@ -128,6 +132,7 @@ class VimSettingPanel {
       this.Text.Text := this.Values[Key]
       this.Text.Visible := True
     }
+    this.ResizeDetails()
   }
 
   HideEditors() {
@@ -153,9 +158,15 @@ class VimSettingPanel {
       Value := this.Text.Text
     }
     this.Values[this.CurrentKey] := Value
-    for Row, Key in this.RowKeys {
-      if (Key == this.CurrentKey) {
-        this.List.Modify(Row, "Col2", VimSettingSchema.Summary(Setting, Value, this.Delimiter))
+    this.UpdateSummary(this.CurrentKey)
+  }
+
+  UpdateSummary(SettingKey) {
+    for Row, RowKey in this.RowKeys {
+      if (RowKey == SettingKey) {
+        this.List.Modify(Row, "Col2"
+          , VimSettingSchema.Summary(this.Schema[SettingKey]
+            , this.Values[SettingKey], this.Delimiter))
         break
       }
     }
@@ -187,6 +198,29 @@ class VimSettingPanel {
     this.List.ModifyCol(2, 110)
   }
 
+  ResizeDetails() {
+    NameY := this.DetailsTop
+    InfoY := NameY + 24
+    AvailableHeight := Max(96, this.DetailsBottom - InfoY)
+    Kind := this.CurrentKey == "" ? "text" : this.Schema[this.CurrentKey]["kind"]
+    if (Kind == "list") {
+      InfoHeight := Max(64, Floor((AvailableHeight - 8) * 0.45))
+      EditorY := InfoY + InfoHeight + 8
+      EditorHeight := Max(40, this.DetailsBottom - EditorY)
+    } else {
+      EditorHeight := 24
+      EditorY := this.DetailsBottom - EditorHeight
+      InfoHeight := Max(64, EditorY - InfoY - 8)
+    }
+
+    this.Name.Move(this.RightX, NameY, this.RightWidth, 22)
+    this.Info.Move(this.RightX, InfoY, this.RightWidth, InfoHeight)
+    this.Boolean.Move(this.RightX, EditorY, this.RightWidth, 24)
+    this.Choice.Move(this.RightX, EditorY, Min(320, this.RightWidth), 24)
+    this.Text.Move(this.RightX, EditorY, this.RightWidth, 24)
+    this.ListText.Move(this.RightX, EditorY, this.RightWidth, EditorHeight)
+  }
+
   Resize(Width, Height, FooterTop) {
     Margin := 12
     LeftWidth := 170
@@ -195,23 +229,19 @@ class VimSettingPanel {
     RightWidth := Max(300, Width - RightX - Margin)
     ContentTop := 46
     ContentHeight := Max(280, FooterTop - ContentTop - Gap)
-    ListHeight := Max(150, Floor(ContentHeight * 0.55))
+    ListHeight := Max(130, Floor(ContentHeight * 0.45))
     NameY := ContentTop + ListHeight + 12
-    InfoY := NameY + 24
-    EditorY := InfoY + 58
-    EditorHeight := Max(24, FooterTop - EditorY - Gap)
 
     this.SearchLabel.Move(Margin, Margin + 3, 48, 20)
     this.Search.Move(Margin + 52, Margin, Width - Margin * 2 - 52)
     this.Category.Move(Margin, ContentTop, LeftWidth, ContentHeight)
     this.List.Move(RightX, ContentTop, RightWidth, ListHeight)
     this.ListWidth := RightWidth
-    this.Name.Move(RightX, NameY, RightWidth, 22)
-    this.Info.Move(RightX, InfoY, RightWidth, 52)
-    this.Boolean.Move(RightX, EditorY, RightWidth, 24)
-    this.Choice.Move(RightX, EditorY, Min(320, RightWidth), 24)
-    this.Text.Move(RightX, EditorY, RightWidth, 24)
-    this.ListText.Move(RightX, EditorY, RightWidth, EditorHeight)
+    this.RightX := RightX
+    this.RightWidth := RightWidth
+    this.DetailsTop := NameY
+    this.DetailsBottom := FooterTop - Gap
+    this.ResizeDetails()
     this.ResizeColumns()
   }
 }

--- a/lib/vim_setting_panel.ahk
+++ b/lib/vim_setting_panel.ahk
@@ -20,8 +20,7 @@ class VimSettingPanel {
     this.Search := this.Gui.Add("Edit", "x64 y12 w684")
     this.Category := this.Gui.Add("ListBox", "x12 y46 w170 h380")
     this.List := this.Gui.Add("ListView", "x194 y46 w554 h240 -Multi", ["Setting", "Value"])
-    this.Name := this.Gui.Add("Text", "x194 y298 w554 h22")
-    this.Info := this.Gui.Add("Text", "x194 y322 w554 h110")
+    this.Details := this.Gui.Add("Edit", "x194 y298 w554 h134 ReadOnly Multi VScroll")
     this.Boolean := this.Gui.Add("CheckBox", "x194 y440 w554", "Enabled")
     this.Choice := this.Gui.Add("DropDownList", "x194 y440 w300")
     this.Text := this.Gui.Add("Edit", "x194 y440 w554")
@@ -91,8 +90,7 @@ class VimSettingPanel {
       this.ShowEditor(this.RowKeys[SelectedRow])
     } else {
       this.CurrentKey := ""
-      this.Name.Text := ""
-      this.Info.Text := ""
+      this.Details.Text := ""
       this.HideEditors()
     }
   }
@@ -106,8 +104,7 @@ class VimSettingPanel {
   ShowEditor(Key) {
     this.CurrentKey := Key
     Setting := this.Schema[Key]
-    this.Name.Text := Setting["description"]
-    this.Info.Text := Setting["info"]
+    this.Details.Text := Setting["description"] "`r`n`r`n" Setting["info"]
     this.HideEditors()
     Kind := Setting["kind"]
     if (Kind == "boolean") {
@@ -194,43 +191,42 @@ class VimSettingPanel {
   }
 
   ResizeColumns() {
-    this.List.ModifyCol(1, Max(180, this.ListWidth - 120))
-    this.List.ModifyCol(2, 110)
+    ValueWidth := Min(140, Floor(this.ListWidth * 0.30))
+    this.List.ModifyCol(1, this.ListWidth - ValueWidth - 20)
+    this.List.ModifyCol(2, ValueWidth)
   }
 
   ResizeDetails() {
-    NameY := this.DetailsTop
-    InfoY := NameY + 24
-    AvailableHeight := Max(96, this.DetailsBottom - InfoY)
+    Gap := 8
+    AvailableHeight := this.DetailsBottom - this.DetailsTop
     Kind := this.CurrentKey == "" ? "text" : this.Schema[this.CurrentKey]["kind"]
     if (Kind == "list") {
-      InfoHeight := Max(64, Floor((AvailableHeight - 8) * 0.45))
-      EditorY := InfoY + InfoHeight + 8
-      EditorHeight := Max(40, this.DetailsBottom - EditorY)
+      DetailsHeight := Floor((AvailableHeight - Gap) * 0.45)
+      EditorY := this.DetailsTop + DetailsHeight + Gap
+      EditorHeight := this.DetailsBottom - EditorY
     } else {
       EditorHeight := 24
       EditorY := this.DetailsBottom - EditorHeight
-      InfoHeight := Max(64, EditorY - InfoY - 8)
+      DetailsHeight := EditorY - this.DetailsTop - Gap
     }
 
-    this.Name.Move(this.RightX, NameY, this.RightWidth, 22)
-    this.Info.Move(this.RightX, InfoY, this.RightWidth, InfoHeight)
+    this.Details.Move(this.RightX, this.DetailsTop, this.RightWidth, DetailsHeight)
     this.Boolean.Move(this.RightX, EditorY, this.RightWidth, 24)
     this.Choice.Move(this.RightX, EditorY, Min(320, this.RightWidth), 24)
     this.Text.Move(this.RightX, EditorY, this.RightWidth, 24)
     this.ListText.Move(this.RightX, EditorY, this.RightWidth, EditorHeight)
   }
 
-  Resize(Width, Height, FooterTop) {
+  Resize(Width, FooterTop, Narrow) {
     Margin := 12
-    LeftWidth := 170
-    Gap := 12
+    Gap := Narrow ? 8 : 12
+    LeftWidth := Min(170, Floor(Width * 0.28))
     RightX := Margin + LeftWidth + Gap
-    RightWidth := Max(300, Width - RightX - Margin)
+    RightWidth := Width - RightX - Margin
     ContentTop := 46
-    ContentHeight := Max(280, FooterTop - ContentTop - Gap)
-    ListHeight := Max(130, Floor(ContentHeight * 0.45))
-    NameY := ContentTop + ListHeight + 12
+    ContentHeight := FooterTop - ContentTop - Gap
+    ListHeight := Floor(ContentHeight * 0.43)
+    DetailsTop := ContentTop + ListHeight + Gap
 
     this.SearchLabel.Move(Margin, Margin + 3, 48, 20)
     this.Search.Move(Margin + 52, Margin, Width - Margin * 2 - 52)
@@ -239,7 +235,7 @@ class VimSettingPanel {
     this.ListWidth := RightWidth
     this.RightX := RightX
     this.RightWidth := RightWidth
-    this.DetailsTop := NameY
+    this.DetailsTop := DetailsTop
     this.DetailsBottom := FooterTop - Gap
     this.ResizeDetails()
     this.ResizeColumns()

--- a/lib/vim_setting_panel.ahk
+++ b/lib/vim_setting_panel.ahk
@@ -2,174 +2,212 @@
 
 
 class VimSettingPanel {
-  __New(GuiObj, Schema, Delimiter) {
+  static KeysCategory := "Mode keys"
+  static StatusCategory := "Status"
+  static MainGroupKey := "VimGroup"
+  static AppListKey := "VimAppList"
+  static UpDownNoThousandsOption := "0x80"
+
+  __New(GuiObj, TabObj, Schema, Delimiter) {
     this.Gui := GuiObj
+    this.Tab := TabObj
     this.Schema := Schema
     this.Delimiter := Delimiter
     this.Values := VimSettingSchema.Values(Schema)
-    this.RowKeys := Map()
-    this.Categories := []
-    this.CurrentKey := ""
+    this.Controls := Map()
+    this.GroupKeys := []
+    this.CurrentGroupKey := ""
+    this.Loading := False
 
-    this.SearchLabel := this.Gui.Add("Text", "x0 y0 w0 h0", "Search:")
-    this.Search := this.Gui.Add("Edit", "x0 y0 w0 h0")
-    this.Category := this.Gui.Add("ListBox", "x0 y0 w0 h0")
-    this.List := this.Gui.Add("ListView", "x0 y0 w0 h0 -Multi", ["Setting", "Value"])
-    this.Details := this.Gui.Add("Edit", "x0 y0 w0 h0 ReadOnly Multi VScroll")
-    this.Boolean := this.Gui.Add("CheckBox", "x0 y0 w0 h0", "Enabled")
-    this.Choice := this.Gui.Add("DropDownList", "x0 y0 w0 h0")
-    this.Text := this.Gui.Add("Edit", "x0 y0 w0 h0")
-    this.ListText := this.Gui.Add("Edit", "x0 y0 w0 h0 Multi VScroll WantTab")
-
-    this.Search.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
-    this.Category.OnEvent("Change", ObjBindMethod(this, "FilterChanged"))
-    this.List.OnEvent("ItemSelect", ObjBindMethod(this, "ItemSelected"))
-    this.Boolean.OnEvent("Click", ObjBindMethod(this, "EditorChanged"))
-    this.Choice.OnEvent("Change", ObjBindMethod(this, "EditorChanged"))
-    this.Text.OnEvent("Change", ObjBindMethod(this, "EditorChanged"))
-    this.ListText.OnEvent("Change", ObjBindMethod(this, "EditorChanged"))
-
-    this.LoadCategories()
-    this.HideEditors()
+    this.BuildKeysTab()
+    this.BuildApplicationsTab()
+    this.BuildStatusTab()
+    this.Tab.UseTab()
+    this.ValidateCoverage()
+    this.LoadValues(this.Values)
   }
 
-  LoadCategories() {
-    Seen := Map()
-    this.Categories := ["All"]
-    for , Setting in this.Schema {
-      Category := Setting["category"]
-      if !Seen.Has(Category) {
-        Seen[Category] := True
-        this.Categories.Push(Category)
-      }
-    }
-    this.Category.Delete()
-    this.Category.Add(this.Categories)
-    this.Category.Choose(1)
-  }
-
-  FilterChanged(Control, Info) {
-    this.RefreshList()
-  }
-
-  RefreshList() {
-    PreferredKey := this.CurrentKey
-    CategoryIndex := this.Category.Value
-    Category := CategoryIndex ? this.Categories[CategoryIndex] : "All"
-    Query := StrLower(Trim(this.Search.Text))
-    this.List.Delete()
-    this.RowKeys := Map()
-    SelectedRow := 0
+  BuildKeysTab() {
+    this.Tab.UseTab(1)
+    this.Gui.Add("Text", "X+0 Y+0 Section", "")
     for Key, Setting in this.Schema {
-      if (Category != "All" && Setting["category"] != Category) {
+      if (Setting["category"] != VimSettingPanel.KeysCategory) {
         continue
       }
-      SearchText := StrLower(Key " " Setting["description"] " " Setting["info"])
-      if (Query != "" && !InStr(SearchText, Query)) {
-        continue
+      Kind := Setting["kind"]
+      if (Kind == "boolean") {
+        Control := this.Gui.Add("CheckBox", "XS+10 Y+6", Setting["description"])
+      } else if (Kind == "list") {
+        this.Gui.Add("Text", "XS+10 Y+12", Setting["description"])
+        Control := this.Gui.Add("Edit", "XS+10 Y+5 R4 W150 Multi VScroll WantTab")
+      } else if (Kind == "choice") {
+        this.Gui.Add("Text", "XS+10 Y+12", Setting["description"])
+        Control := this.Gui.Add("DropDownList", "X+5 YP-4 W80")
+        Control.Add(Setting["choices"])
+      } else {
+        throw ValueError("Unsupported setting kind in Keys tab: " Kind)
       }
-      Row := this.List.Add("", Setting["description"]
-        , VimSettingSchema.Summary(Setting, this.Values[Key], this.Delimiter))
-      this.RowKeys[Row] := Key
-      if (Key == PreferredKey) {
-        SelectedRow := Row
-      }
-    }
-    this.ResizeColumns()
-    if (!SelectedRow && this.RowKeys.Count) {
-      SelectedRow := 1
-    }
-    if SelectedRow {
-      this.List.Modify(SelectedRow, "Select Focus Vis")
-      this.ShowEditor(this.RowKeys[SelectedRow])
-    } else {
-      this.CurrentKey := ""
-      this.Details.Text := ""
-      this.HideEditors()
+      this.RegisterControl(Key, Control)
     }
   }
 
-  ItemSelected(Control, Row, Selected) {
-    if (Selected && this.RowKeys.Has(Row)) {
-      this.ShowEditor(this.RowKeys[Row])
-    }
+  BuildApplicationsTab() {
+    this.Tab.UseTab(2)
+    this.Gui.Add("Text", "X+0 Y+0 Section", "")
+    this.AddApplicationChoice("VimSetTitleMatchMode", "XS+10 Y+10", "X+5 YP-4 W90")
+    this.AddApplicationChoice("VimSetTitleMatchModeFS", "XS+10 Y+12", "X+5 YP-4 W90")
+
+    this.ApplicationGroupLabel := this.Gui.Add("Text", "XS+10 Y+15", "Application group")
+    this.ApplicationGroup := this.Gui.Add("DropDownList", "X+5 YP-4 W260")
+    this.LoadApplicationGroups()
+
+    AppListSetting := this.Schema[VimSettingPanel.AppListKey]
+    this.AppListLabel := this.Gui.Add("Text", "XS+10 Y+12", AppListSetting["description"])
+    this.AppList := this.Gui.Add("DropDownList", "X+5 YP-4 W120")
+    this.AppList.Add(AppListSetting["choices"])
+    this.RegisterControl(VimSettingPanel.AppListKey, this.AppList)
+
+    this.GroupEditor := this.Gui.Add("Edit", "XS+10 Y+10 R8 W430 Multi VScroll WantTab")
+    this.GroupInfo := this.Gui.Add("Text", "XS+10 Y+8 W430 H48", "")
+    this.ApplicationGroup.OnEvent("Change", ObjBindMethod(this, "ApplicationGroupChanged"))
   }
 
-  ShowEditor(Key) {
-    this.CurrentKey := Key
+  AddApplicationChoice(Key, LabelOptions, ControlOptions) {
     Setting := this.Schema[Key]
-    this.Details.Text := Setting["description"] "`r`n`r`n" Setting["info"]
-    this.HideEditors()
-    Kind := Setting["kind"]
-    if (Kind == "boolean") {
-      this.Boolean.Value := this.Values[Key]
-      this.Boolean.Visible := True
-    } else if (Kind == "choice") {
-      this.Choice.Delete()
-      this.Choice.Add(Setting["choices"])
-      ChoiceIndex := 0
-      for Index, Choice in Setting["choices"] {
-        if (Choice == this.Values[Key]) {
-          ChoiceIndex := Index
-          break
-        }
-      }
-      this.Choice.Choose(ChoiceIndex)
-      this.Choice.Visible := True
-    } else if (Kind == "list") {
-      this.ListText.Text := VimSettingSchema.ToEditor(Setting, this.Values[Key], this.Delimiter)
-      this.ListText.Visible := True
-    } else {
-      this.Text.Text := this.Values[Key]
-      this.Text.Visible := True
+    this.Gui.Add("Text", LabelOptions, Setting["description"])
+    Control := this.Gui.Add("DropDownList", ControlOptions)
+    Control.Add(Setting["choices"])
+    this.RegisterControl(Key, Control)
+  }
+
+  LoadApplicationGroups() {
+    if !this.Schema.Has(VimSettingPanel.MainGroupKey) {
+      throw ValueError("Missing application group setting: " VimSettingPanel.MainGroupKey)
     }
-    this.ResizeDetails()
+    this.GroupKeys.Push(VimSettingPanel.MainGroupKey)
+    Descriptions := [this.Schema[VimSettingPanel.MainGroupKey]["description"]]
+    for Key, Setting in this.Schema {
+      if (Setting["group"] == "") {
+        continue
+      }
+      this.GroupKeys.Push(Key)
+      Descriptions.Push(Setting["description"])
+    }
+    this.ApplicationGroup.Add(Descriptions)
   }
 
-  HideEditors() {
-    this.Boolean.Visible := False
-    this.Choice.Visible := False
-    this.Text.Visible := False
-    this.ListText.Visible := False
+  BuildStatusTab() {
+    this.Tab.UseTab(3)
+    this.Gui.Add("Text", "X+0 Y+0 Section", "")
+    for Key, Setting in this.Schema {
+      if (Setting["category"] != VimSettingPanel.StatusCategory) {
+        continue
+      }
+      Kind := Setting["kind"]
+      this.Gui.Add("Text", "XS+10 Y+10", Setting["description"])
+      if (Kind == "integer") {
+        Control := this.Gui.Add("Edit", "X+5 YP-4 W80")
+        UpDownOptions := VimSettingPanel.UpDownNoThousandsOption
+        if (Setting["min"] != "" && Setting["max"] != "") {
+          UpDownOptions .= " Range" Setting["min"] "-" Setting["max"]
+        }
+        this.Gui.Add("UpDown", UpDownOptions)
+      } else if (Kind == "choice") {
+        Control := this.Gui.Add("DropDownList", "X+5 YP-4 W80")
+        Control.Add(Setting["choices"])
+      } else {
+        throw ValueError("Unsupported setting kind in Status tab: " Kind)
+      }
+      this.RegisterControl(Key, Control)
+    }
   }
 
-  EditorChanged(Control, Info) {
-    if (this.CurrentKey == "") {
+  RegisterControl(Key, Control) {
+    if !this.Schema.Has(Key) {
+      throw ValueError("Unknown setting control: " Key)
+    }
+    if this.Controls.Has(Key) {
+      throw ValueError("Duplicate setting control: " Key)
+    }
+    this.Controls[Key] := Control
+  }
+
+  ValidateCoverage() {
+    Covered := Map()
+    for Key in this.Controls {
+      Covered[Key] := True
+    }
+    for Key in this.GroupKeys {
+      if Covered.Has(Key) {
+        throw ValueError("Duplicate setting editor: " Key)
+      }
+      Covered[Key] := True
+    }
+    for Key in this.Schema {
+      if !Covered.Has(Key) {
+        throw ValueError("Missing setting editor: " Key)
+      }
+    }
+  }
+
+  ApplicationGroupChanged(Control, Info) {
+    if this.Loading {
       return
     }
-    Setting := this.Schema[this.CurrentKey]
-    Kind := Setting["kind"]
-    if (Kind == "boolean") {
-      Value := this.Boolean.Value
-    } else if (Kind == "choice") {
-      Value := this.Choice.Text
-    } else if (Kind == "list") {
-      Value := VimSettingSchema.NormalizeList(this.ListText.Text, this.Delimiter)
-    } else {
-      Value := this.Text.Text
+    this.CommitCurrentApplicationGroup()
+    Index := Control.Value
+    if (Index < 1 || Index > this.GroupKeys.Length) {
+      throw ValueError("Invalid application group selection.")
     }
-    this.Values[this.CurrentKey] := Value
-    this.UpdateSummary(this.CurrentKey)
+    this.ShowApplicationGroup(this.GroupKeys[Index])
   }
 
-  UpdateSummary(SettingKey) {
-    for Row, RowKey in this.RowKeys {
-      if (RowKey == SettingKey) {
-        this.List.Modify(Row, "Col2"
-          , VimSettingSchema.Summary(this.Schema[SettingKey]
-            , this.Values[SettingKey], this.Delimiter))
-        break
-      }
+  CommitCurrentApplicationGroup() {
+    if (this.CurrentGroupKey == "") {
+      return
     }
+    this.Values[this.CurrentGroupKey] := VimSettingSchema.NormalizeList(
+      this.GroupEditor.Text, this.Delimiter)
+  }
+
+  ShowApplicationGroup(Key) {
+    if !this.Schema.Has(Key) {
+      throw ValueError("Unknown application group: " Key)
+    }
+    Setting := this.Schema[Key]
+    if (Setting["kind"] != "list") {
+      throw ValueError("Application group requires a list setting: " Key)
+    }
+    this.CurrentGroupKey := Key
+    this.GroupEditor.Text := VimSettingSchema.ToEditor(
+      Setting, this.Values[Key], this.Delimiter)
+    this.GroupInfo.Text := Setting["info"]
+    ShowAppList := Key == VimSettingPanel.MainGroupKey
+    this.AppListLabel.Visible := ShowAppList
+    this.AppList.Visible := ShowAppList
   }
 
   LoadValues(Values) {
-    for Key in this.Schema {
-      if Values.Has(Key) {
+    this.Loading := True
+    try {
+      for Key in this.Schema {
+        if !Values.Has(Key) {
+          throw ValueError("Missing setting value: " Key)
+        }
         this.Values[Key] := Values[Key]
       }
+      for Key, Control in this.Controls {
+        this.SetControlValue(Key, Control, this.Values[Key])
+      }
+      GroupKey := this.CurrentGroupKey
+      if (GroupKey == "") {
+        GroupKey := this.GroupKeys[1]
+      }
+      this.ApplicationGroup.Choose(this.ApplicationGroupIndex(GroupKey))
+      this.ShowApplicationGroup(GroupKey)
+    } finally {
+      this.Loading := False
     }
-    this.RefreshList()
   }
 
   LoadDefaults() {
@@ -177,57 +215,62 @@ class VimSettingPanel {
   }
 
   NormalizedValues() {
-    return VimSettingSchema.NormalizeValues(this.Schema, this.Values, this.Delimiter)
-  }
-
-  ResizeColumns() {
-    ValueWidth := Min(140, Floor(this.ListWidth * 0.30))
-    this.List.ModifyCol(1, this.ListWidth - ValueWidth - 20)
-    this.List.ModifyCol(2, ValueWidth)
-  }
-
-  ResizeDetails() {
-    Gap := 8
-    AvailableHeight := this.DetailsBottom - this.DetailsTop
-    Kind := this.CurrentKey == "" ? "text" : this.Schema[this.CurrentKey]["kind"]
-    if (Kind == "list") {
-      DetailsHeight := Floor((AvailableHeight - Gap) * 0.45)
-      EditorY := this.DetailsTop + DetailsHeight + Gap
-      EditorHeight := this.DetailsBottom - EditorY
-    } else {
-      EditorHeight := 24
-      EditorY := this.DetailsBottom - EditorHeight
-      DetailsHeight := EditorY - this.DetailsTop - Gap
+    this.CommitCurrentApplicationGroup()
+    for Key, Control in this.Controls {
+      this.Values[Key] := this.ControlValue(Key, Control)
     }
-
-    this.Details.Move(this.RightX, this.DetailsTop, this.RightWidth, DetailsHeight)
-    this.Boolean.Move(this.RightX, EditorY, this.RightWidth, 24)
-    this.Choice.Move(this.RightX, EditorY, Min(320, this.RightWidth), 24)
-    this.Text.Move(this.RightX, EditorY, this.RightWidth, 24)
-    this.ListText.Move(this.RightX, EditorY, this.RightWidth, EditorHeight)
+    return VimSettingSchema.NormalizeValues(
+      this.Schema, this.Values, this.Delimiter)
   }
 
-  Resize(Width, FooterTop, Narrow) {
-    Margin := 12
-    Gap := Narrow ? 8 : 12
-    LeftWidth := Min(170, Floor(Width * 0.28))
-    RightX := Margin + LeftWidth + Gap
-    RightWidth := Width - RightX - Margin
-    ContentTop := 46
-    ContentHeight := FooterTop - ContentTop - Gap
-    ListHeight := Floor(ContentHeight * 0.43)
-    DetailsTop := ContentTop + ListHeight + Gap
+  SetControlValue(Key, Control, Value) {
+    Setting := this.Schema[Key]
+    Kind := Setting["kind"]
+    if (Kind == "boolean") {
+      Control.Value := Value ? 1 : 0
+    } else if (Kind == "choice") {
+      Control.Choose(this.ChoiceIndex(Setting, Value))
+    } else if (Kind == "list") {
+      Control.Text := VimSettingSchema.ToEditor(Setting, Value, this.Delimiter)
+    } else if (Kind == "integer") {
+      Control.Text := Value
+    } else {
+      throw ValueError("Unsupported setting kind: " Kind)
+    }
+  }
 
-    this.SearchLabel.Move(Margin, Margin + 3, 48, 20)
-    this.Search.Move(Margin + 52, Margin, Width - Margin * 2 - 52)
-    this.Category.Move(Margin, ContentTop, LeftWidth, ContentHeight)
-    this.List.Move(RightX, ContentTop, RightWidth, ListHeight)
-    this.ListWidth := RightWidth
-    this.RightX := RightX
-    this.RightWidth := RightWidth
-    this.DetailsTop := DetailsTop
-    this.DetailsBottom := FooterTop - Gap
-    this.ResizeDetails()
-    this.ResizeColumns()
+  ControlValue(Key, Control) {
+    Kind := this.Schema[Key]["kind"]
+    if (Kind == "boolean") {
+      return Control.Value
+    }
+    if (Kind == "choice") {
+      return Control.Text
+    }
+    if (Kind == "list") {
+      return VimSettingSchema.NormalizeList(Control.Text, this.Delimiter)
+    }
+    if (Kind == "integer") {
+      return Control.Text
+    }
+    throw ValueError("Unsupported setting kind: " Kind)
+  }
+
+  ChoiceIndex(Setting, Value) {
+    for Index, Choice in Setting["choices"] {
+      if (Choice == Value) {
+        return Index
+      }
+    }
+    throw ValueError(Setting["description"] " has an invalid value.")
+  }
+
+  ApplicationGroupIndex(Key) {
+    for Index, GroupKey in this.GroupKeys {
+      if (GroupKey == Key) {
+        return Index
+      }
+    }
+    throw ValueError("Unknown application group: " Key)
   }
 }

--- a/lib/vim_setting_panel.ahk
+++ b/lib/vim_setting_panel.ahk
@@ -85,15 +85,19 @@ class VimSettingPanel {
       throw ValueError("Missing application group setting: " VimSettingPanel.MainGroupKey)
     }
     this.GroupKeys.Push(VimSettingPanel.MainGroupKey)
-    Descriptions := [this.Schema[VimSettingPanel.MainGroupKey]["description"]]
+    Labels := [this.Schema[VimSettingPanel.MainGroupKey]["description"]]
     for Key, Setting in this.Schema {
       if (Setting["group"] == "") {
         continue
       }
+      Label := Setting["label"]
+      if (Label == "") {
+        throw ValueError("Missing application group label: " Key)
+      }
       this.GroupKeys.Push(Key)
-      Descriptions.Push(Setting["description"])
+      Labels.Push(Label)
     }
-    this.ApplicationGroup.Add(Descriptions)
+    this.ApplicationGroup.Add(Labels)
   }
 
   BuildStatusTab() {

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -1,0 +1,120 @@
+class VimSettingSchema {
+  static Add(Schema, Key, Default, Category, Kind, Description, Info
+      , Choices := 0, Min := "", Max := "", Group := "", Reload := False) {
+    if !(Choices is Array) {
+      Choices := []
+    }
+    Schema[Key] := Map(
+      "default", Default,
+      "val", Default,
+      "category", Category,
+      "kind", Kind,
+      "description", Description,
+      "info", Info,
+      "choices", Choices,
+      "min", Min,
+      "max", Max,
+      "group", Group,
+      "reload", Reload)
+  }
+
+  static Copy(Schema) {
+    Copy := Map()
+    for Key, Setting in Schema {
+      Item := Map()
+      for Name, Value in Setting {
+        Item[Name] := Value
+      }
+      Copy[Key] := Item
+    }
+    return Copy
+  }
+
+  static Values(Schema, Defaults := False) {
+    Values := Map()
+    Field := Defaults ? "default" : "val"
+    for Key, Setting in Schema {
+      Values[Key] := Setting[Field]
+    }
+    return Values
+  }
+
+  static Normalize(Setting, Value, Delimiter) {
+    Kind := Setting["kind"]
+    if (Kind == "boolean") {
+      return Value ? 1 : 0
+    }
+    if (Kind == "integer") {
+      if !IsInteger(Value) {
+        throw ValueError(Setting["description"] " requires an integer.")
+      }
+      Value := Integer(Value)
+      if (Setting["min"] != "" && Value < Setting["min"]) {
+        throw ValueError(Setting["description"] " must be at least " Setting["min"] ".")
+      }
+      if (Setting["max"] != "" && Value > Setting["max"]) {
+        throw ValueError(Setting["description"] " must be at most " Setting["max"] ".")
+      }
+      return Value
+    }
+    if (Kind == "choice") {
+      for Choice in Setting["choices"] {
+        if (Value == Choice) {
+          return Choice
+        }
+      }
+      throw ValueError(Setting["description"] " has an invalid value.")
+    }
+    if (Kind == "list") {
+      return this.NormalizeList(Value, Delimiter)
+    }
+    return Value
+  }
+
+  static NormalizeList(Value, Delimiter) {
+    Value := StrReplace(Value, "`r`n", "`n")
+    Value := StrReplace(Value, "`r", "`n")
+    Value := StrReplace(Value, Delimiter, "`n")
+    Seen := Map()
+    Items := []
+    Loop Parse, Value, "`n" {
+      Item := Trim(A_LoopField)
+      if (Item != "" && !Seen.Has(Item)) {
+        Seen[Item] := True
+        Items.Push(Item)
+      }
+    }
+    Result := ""
+    for Item in Items {
+      Result .= (Result == "" ? "" : Delimiter) Item
+    }
+    return Result
+  }
+
+  static ToEditor(Setting, Value, Delimiter) {
+    if (Setting["kind"] == "list") {
+      return StrReplace(Value, Delimiter, "`r`n")
+    }
+    return Value
+  }
+
+  static Summary(Setting, Value, Delimiter) {
+    Kind := Setting["kind"]
+    if (Kind == "boolean") {
+      return Value ? "On" : "Off"
+    }
+    if (Kind == "list") {
+      if (Value == "") {
+        return "0 entries"
+      }
+      Count := 0
+      Loop Parse, Value, Delimiter {
+        if (A_LoopField != "") {
+          Count++
+        }
+      }
+      return Count " entries"
+    }
+    return Value
+  }
+}

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -1,4 +1,147 @@
 class VimSettingSchema {
+  static Build(DefaultGroup, Delimiter := ",") {
+    Schema := Map()
+
+    this.Add(Schema, "VimEscNormal", 1, "Mode keys", "boolean"
+      , "ESC to enter the normal mode"
+      , "If checked, pressing ESC enters normal mode.")
+    this.Add(Schema, "VimEscNormalDirect", 1, "Mode keys", "boolean"
+      , "ESC to enter the normal mode directly even if converting in IME"
+      , "If checked, ESC enters normal mode even while IME is converting.`nIf not checked, ESC behaves as normal ESC while IME is converting.")
+    this.Add(Schema, "VimSendEscNormal", 0, "Mode keys", "boolean"
+      , "Send ESC by ESC at the normal mode"
+      , "If checked, a short ESC press sends ESC in normal mode.`nEnable ESC to enter normal mode first.")
+    this.Add(Schema, "VimLongEscNormal", 0, "Mode keys", "boolean"
+      , "Long press ESC to enter the normal mode"
+      , "If checked, short and long press behavior of ESC is swapped.`nEnable ESC to enter normal mode first.")
+    this.Add(Schema, "VimCtrlBracketToEsc", 1, "Mode keys", "boolean"
+      , "Ctrl-[ to ESC"
+      , "If checked, Ctrl-[ behaves as ESC.`nIf Ctrl-[ to normal mode is disabled, Ctrl-[ always sends ESC.`nIf both are checked, long press Ctrl-[ sends ESC.")
+    this.Add(Schema, "VimCtrlBracketNormal", 1, "Mode keys", "boolean"
+      , "Ctrl-[ to enter the normal mode"
+      , "If checked, pressing Ctrl-[ enters normal mode.")
+    this.Add(Schema, "VimCtrlBracketNormalDirect", 1, "Mode keys", "boolean"
+      , "Ctrl-[ to enter the normal mode directly even if converting in IME"
+      , "If checked, Ctrl-[ enters normal mode even while IME is converting.`nIf not checked, Ctrl-[ behaves as ESC while IME is converting.")
+    this.Add(Schema, "VimSendCtrlBracketNormal", 0, "Mode keys", "boolean"
+      , "Send Ctrl-[ by Ctrl-[ at the normal mode"
+      , "If checked, a short Ctrl-[ press sends Ctrl-[ in normal mode.`nEnable Ctrl-[ to enter normal mode first.")
+    this.Add(Schema, "VimLongCtrlBracketNormal", 0, "Mode keys", "boolean"
+      , "Long press Ctrl-[ to enter the normal mode"
+      , "If checked, short and long press behavior of Ctrl-[ is swapped.`nEnable Ctrl-[ to enter normal mode first.")
+    this.Add(Schema, "VimChangeCaretWidth", 0, "Mode keys", "boolean"
+      , "Change to thick text caret when in normal mode"
+      , "If checked, caret width changes by mode (thick in normal/visual, thin in insert).`nIt may not work in all applications and can briefly change window focus.")
+    this.Add(Schema, "VimRestoreIME", 1, "Mode keys", "boolean"
+      , "Restore IME status at entering the insert mode"
+      , "If checked, IME status is saved in insert mode and restored when returning to insert mode.")
+    this.Add(Schema, "VimJJ", 0, "Mode keys", "boolean"
+      , "JJ to enter the normal mode"
+      , "If checked, `jj` enters normal mode from insert mode.")
+    this.Add(Schema, "VimTwoLetter", "", "Mode keys", "list"
+      , "Two-letter to enter the normal mode"
+      , "Two-letter mappings to enter normal mode from insert mode.`nSet one pair per line.`nEach pair must be exactly two different letters.")
+    this.Add(Schema, "VimDisableUnused", 1, "Mode keys", "choice"
+      , "Disable unused keys in the normal mode"
+      , "Disable level for unused keys outside insert mode:`n1: Do not disable unused keys`n2: Disable alphabets (+Shift) and symbols`n3: Disable all, including modified keys (e.g. Ctrl+Z)"
+      , [1, 2, 3])
+
+    this.Add(Schema, "VimSetTitleMatchMode", "2", "Applications", "choice"
+      , "Window title match mode"
+      , "SetTitleMatchMode mode:`n1: Start with`n2: Contain`n3: Exact match`nRegEx: Regular expression"
+      , ["1", "2", "3", "RegEx"])
+    this.Add(Schema, "VimSetTitleMatchModeFS", "Fast", "Applications", "choice"
+      , "Window title matching speed"
+      , "SetTitleMatchMode speed:`nFast: Text is not detected for some edit controls`nSlow: Works for all windows, but slower"
+      , ["Fast", "Slow"])
+    this.Add(Schema, "VimAppList", "Allow List", "Applications", "choice"
+      , "Application list usage"
+      , "Application list mode:`nAll: Enable vim_ahk on all applications (ignore the list)`nAllow List: Use list as allow list`nDeny List: Use list as deny list"
+      , ["All", "Allow List", "Deny List"])
+    this.Add(Schema, "VimGroup", DefaultGroup, "Applications", "list"
+      , "Application list"
+      , "Applications where vim_ahk is enabled.`nSet one application per line.`nEach line can be Window Title, Class, or Process.")
+
+    this.AddApplicationGroup(Schema, "VimNonEditor"
+      , ["ahk_exe explorer.exe", "ahk_exe q-dir_x64.exe", "ahk_exe q-dir.exe"
+        , "ahk_exe chrome.exe", "ahk_exe msedge.exe", "ahk_exe firefox.exe"
+        , "ahk_exe waterfox.exe", "ahk_exe brave.exe", "ahk_exe vivaldi.exe"
+        , "ahk_exe opera.exe"]
+      , "Non-editor applications"
+      , "Enter keeps its native behavior in normal mode, and G sends End in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimLBSelectGroup"
+      , ["ahk_exe powerpnt.exe", "ahk_exe winword.exe", "ahk_exe wordpad.exe", "ahk_exe notepad.exe"]
+      , "Applications that select line breaks"
+      , "Shift+End includes the line break in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimNoLBCopyGroup"
+      , ["ahk_exe evernote.exe"]
+      , "Applications that omit copied line breaks"
+      , "Line-wise copy omits the line break in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCtrlUpDownGroup"
+      , ["ahk_exe onenote.exe"]
+      , "Applications requiring Ctrl+Up and Ctrl+Down"
+      , "Vertical paragraph movement uses Ctrl+Up and Ctrl+Down in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimDoubleHomeGroup"
+      , ["ahk_exe code.exe"]
+      , "Applications requiring Home twice"
+      , "Line-start movement sends Home twice in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCaretMove", []
+      , "Applications supporting caret movement"
+      , "The ^ command moves to the first non-whitespace character in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCursorSameAfterSelect"
+      , ["ahk_exe notepad.exe", "ahk_exe explorer.exe"]
+      , "Applications preserving the cursor after selection"
+      , "The cursor starts from the same position after selection in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimQdir"
+      , ["ahk_exe q-dir_x64.exe", "ahk_exe q-dir.exe"]
+      , "Q-Dir applications"
+      , "Q-Dir-specific normal-mode bindings are active in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimShiftEnter"
+      , ["ahk_exe ChatGPT.exe", "ahk_exe Claude.exe", "ahk_exe Cursor.exe"
+        , "ahk_exe slack.exe", "ahk_exe ms-teams.exe", "ahk_exe Teams.exe"
+        , "ahk_exe Discord.exe", "ahk_exe WhatsApp.exe", "ahk_exe Zoom.exe"
+        , "ahk_exe PhoneExperienceHost.exe", "ahk_exe LINE.exe"]
+      , "Applications using Shift+Enter for line breaks"
+      , "The o and O commands send Shift+Enter in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCtrlEnter", []
+      , "Applications using Ctrl+Enter for line breaks"
+      , "The o and O commands send Ctrl+Enter in these applications."
+      , Delimiter)
+
+    this.Add(Schema, "VimIconCheckInterval", 1000, "Status", "integer"
+      , "Icon check interval (ms)"
+      , "Interval (ms) to check vim_ahk status and update tray icon.`nIf set to 0, the original AHK icon is used."
+      , 0, 0, 1000000)
+    this.Add(Schema, "VimVerbose", 1, "Status", "choice"
+      , "Verbose level"
+      , "Verbose level:`n1: No output`n2: Minimum tooltip (mode only)`n3: Tooltip (all information)`n4: Debug message box (does not auto-close)"
+      , [1, 2, 3, 4])
+
+    return Schema
+  }
+
+  static AddApplicationGroup(Schema, Key, Items, Description, Info, Delimiter) {
+    this.Add(Schema, Key, this.Join(Items, Delimiter), "Application behavior", "list"
+      , Description, Info, 0, "", "", Key, True)
+  }
+
+  static Join(Items, Delimiter) {
+    Result := ""
+    for Item in Items {
+      Result .= (Result == "" ? "" : Delimiter) Item
+    }
+    return Result
+  }
+
   static Add(Schema, Key, Default, Category, Kind, Description, Info
       , Choices := 0, Min := "", Max := "", Group := "", Reload := False) {
     if !(Choices is Array) {
@@ -76,17 +219,13 @@ class VimSettingSchema {
     Value := StrReplace(Value, "`r", "`n")
     Value := StrReplace(Value, Delimiter, "`n")
     Seen := Map()
-    Items := []
+    Result := ""
     Loop Parse, Value, "`n" {
       Item := Trim(A_LoopField)
       if (Item != "" && !Seen.Has(Item)) {
         Seen[Item] := True
-        Items.Push(Item)
+        Result .= (Result == "" ? "" : Delimiter) Item
       }
-    }
-    Result := ""
-    for Item in Items {
-      Result .= (Result == "" ? "" : Delimiter) Item
     }
     return Result
   }

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -131,7 +131,7 @@ class VimSettingSchema {
 
   static AddApplicationGroup(Schema, Key, Items, Description, Info, Delimiter) {
     this.Add(Schema, Key, this.Join(Items, Delimiter), "Application behavior", "list"
-      , Description, Info, 0, "", "", Key, True)
+      , Description, Info, 0, "", "", Key)
   }
 
   static Join(Items, Delimiter) {
@@ -143,7 +143,7 @@ class VimSettingSchema {
   }
 
   static Add(Schema, Key, Default, Category, Kind, Description, Info
-      , Choices := 0, Min := "", Max := "", Group := "", Reload := False) {
+      , Choices := 0, Min := "", Max := "", Group := "") {
     if !(Choices is Array) {
       Choices := []
     }
@@ -157,8 +157,7 @@ class VimSettingSchema {
       "choices", Choices,
       "min", Min,
       "max", Max,
-      "group", Group,
-      "reload", Reload)
+      "group", Group)
   }
 
   static Copy(Schema) {

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -111,11 +111,11 @@ class VimSettingSchema {
         , "ahk_exe PhoneExperienceHost.exe", "ahk_exe LINE.exe"]
       , "Applications using Shift+Enter for line breaks"
       , "The o and O commands send Shift+Enter in these applications."
-      , Delimiter)
+      , Delimiter, ["lineBreakMethod"])
     this.AddApplicationGroup(Schema, "VimCtrlEnter", []
       , "Applications using Ctrl+Enter for line breaks"
       , "The o and O commands send Ctrl+Enter in these applications."
-      , Delimiter)
+      , Delimiter, ["lineBreakMethod"])
 
     this.Add(Schema, "VimIconCheckInterval", 1000, "Status", "integer"
       , "Icon check interval (ms)"
@@ -129,9 +129,10 @@ class VimSettingSchema {
     return Schema
   }
 
-  static AddApplicationGroup(Schema, Key, Items, Description, Info, Delimiter) {
+  static AddApplicationGroup(Schema, Key, Items, Description, Info, Delimiter
+      , ExclusiveGroups := 0) {
     this.Add(Schema, Key, this.Join(Items, Delimiter), "Application behavior", "list"
-      , Description, Info, 0, "", "", Key)
+      , Description, Info, 0, "", "", Key, ExclusiveGroups)
   }
 
   static Join(Items, Delimiter) {
@@ -143,9 +144,12 @@ class VimSettingSchema {
   }
 
   static Add(Schema, Key, Default, Category, Kind, Description, Info
-      , Choices := 0, Min := "", Max := "", Group := "") {
+      , Choices := 0, Min := "", Max := "", Group := "", ExclusiveGroups := 0) {
     if !(Choices is Array) {
       Choices := []
+    }
+    if !(ExclusiveGroups is Array) {
+      ExclusiveGroups := []
     }
     Schema[Key] := Map(
       "default", Default,
@@ -157,7 +161,8 @@ class VimSettingSchema {
       "choices", Choices,
       "min", Min,
       "max", Max,
-      "group", Group)
+      "group", Group,
+      "exclusiveGroups", ExclusiveGroups)
   }
 
   static Copy(Schema) {
@@ -179,6 +184,48 @@ class VimSettingSchema {
       Values[Key] := Setting[Field]
     }
     return Values
+  }
+
+  static ValidateExclusiveGroups(Schema, Values, Delimiter) {
+    Index := Map()
+    for Key, Setting in Schema {
+      for Group in Setting["exclusiveGroups"] {
+        if !Index.Has(Group) {
+          Index[Group] := Map()
+        }
+        Items := Index[Group]
+        Loop Parse, Values[Key], Delimiter {
+          if (A_LoopField == "") {
+            continue
+          }
+          ItemKey := StrLower(A_LoopField)
+          if !Items.Has(ItemKey) {
+            Items[ItemKey] := Map("value", A_LoopField, "owners", [])
+          }
+          Items[ItemKey]["owners"].Push(Key)
+        }
+      }
+    }
+
+    Conflicts := ""
+    for Group, Items in Index {
+      for , Item in Items {
+        if (Item["owners"].Length < 2) {
+          continue
+        }
+        Owners := ""
+        for Key in Item["owners"] {
+          Owners .= (Owners == "" ? "" : ", ") Schema[Key]["description"]
+        }
+        Conflicts .= (Conflicts == "" ? "" : "`n`n")
+          . Group ":`n" Item["value"] "`n" Owners
+      }
+    }
+
+    if (Conflicts != "") {
+      throw ValueError("Each item can belong to one setting in an exclusive group.`n`n"
+        . Conflicts)
+    }
   }
 
   static Normalize(Setting, Value, Delimiter) {

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -67,40 +67,48 @@ class VimSettingSchema {
         , "ahk_exe chrome.exe", "ahk_exe msedge.exe", "ahk_exe firefox.exe"
         , "ahk_exe waterfox.exe", "ahk_exe brave.exe", "ahk_exe vivaldi.exe"
         , "ahk_exe opera.exe"]
+      , "Non-editor"
       , "Non-editor applications"
       , "Enter keeps its native behavior in normal mode, and G sends End in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimLBSelectGroup"
       , ["ahk_exe powerpnt.exe", "ahk_exe winword.exe", "ahk_exe wordpad.exe", "ahk_exe notepad.exe"]
+      , "Select line breaks"
       , "Applications that select line breaks"
       , "Shift+End includes the line break in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimNoLBCopyGroup"
       , ["ahk_exe evernote.exe"]
+      , "Omit copied line breaks"
       , "Applications that omit copied line breaks"
       , "Line-wise copy omits the line break in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimCtrlUpDownGroup"
       , ["ahk_exe onenote.exe"]
+      , "Ctrl+Up/Down"
       , "Applications requiring Ctrl+Up and Ctrl+Down"
       , "Vertical paragraph movement uses Ctrl+Up and Ctrl+Down in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimDoubleHomeGroup"
       , ["ahk_exe code.exe"]
+      , "Double Home"
       , "Applications requiring Home twice"
       , "Line-start movement sends Home twice in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimCaretMove", []
+      , "Caret movement"
       , "Applications supporting caret movement"
       , "The ^ command moves to the first non-whitespace character in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimCursorSameAfterSelect"
       , ["ahk_exe notepad.exe", "ahk_exe explorer.exe"]
+      , "Cursor after select"
       , "Applications preserving the cursor after selection"
       , "The cursor starts from the same position after selection in these applications."
       , Delimiter)
     this.AddApplicationGroup(Schema, "VimQdir"
       , ["ahk_exe q-dir_x64.exe", "ahk_exe q-dir.exe"]
+      , "Q-Dir"
       , "Q-Dir applications"
       , "Q-Dir-specific normal-mode bindings are active in these applications."
       , Delimiter)
@@ -109,10 +117,12 @@ class VimSettingSchema {
         , "ahk_exe slack.exe", "ahk_exe ms-teams.exe", "ahk_exe Teams.exe"
         , "ahk_exe Discord.exe", "ahk_exe WhatsApp.exe", "ahk_exe Zoom.exe"
         , "ahk_exe PhoneExperienceHost.exe", "ahk_exe LINE.exe"]
+      , "Shift+Enter line break"
       , "Applications using Shift+Enter for line breaks"
       , "The o and O commands send Shift+Enter in these applications."
       , Delimiter, ["lineBreakMethod"])
     this.AddApplicationGroup(Schema, "VimCtrlEnter", []
+      , "Ctrl+Enter line break"
       , "Applications using Ctrl+Enter for line breaks"
       , "The o and O commands send Ctrl+Enter in these applications."
       , Delimiter, ["lineBreakMethod"])
@@ -129,10 +139,10 @@ class VimSettingSchema {
     return Schema
   }
 
-  static AddApplicationGroup(Schema, Key, Items, Description, Info, Delimiter
+  static AddApplicationGroup(Schema, Key, Items, Label, Description, Info, Delimiter
       , ExclusiveGroups := 0) {
     this.Add(Schema, Key, this.Join(Items, Delimiter), "Application behavior", "list"
-      , Description, Info, 0, "", "", Key, ExclusiveGroups)
+      , Description, Info, 0, "", "", Key, ExclusiveGroups, Label)
   }
 
   static Join(Items, Delimiter) {
@@ -144,7 +154,8 @@ class VimSettingSchema {
   }
 
   static Add(Schema, Key, Default, Category, Kind, Description, Info
-      , Choices := 0, Min := "", Max := "", Group := "", ExclusiveGroups := 0) {
+      , Choices := 0, Min := "", Max := "", Group := "", ExclusiveGroups := 0
+      , Label := "") {
     if !(Choices is Array) {
       Choices := []
     }
@@ -162,7 +173,8 @@ class VimSettingSchema {
       "min", Min,
       "max", Max,
       "group", Group,
-      "exclusiveGroups", ExclusiveGroups)
+      "exclusiveGroups", ExclusiveGroups,
+      "label", Label)
   }
 
   static Copy(Schema) {

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -186,6 +186,14 @@ class VimSettingSchema {
     return Values
   }
 
+  static NormalizeValues(Schema, Values, Delimiter) {
+    Normalized := Map()
+    for Key, Setting in Schema {
+      Normalized[Key] := this.Normalize(Setting, Values[Key], Delimiter)
+    }
+    return Normalized
+  }
+
   static ValidateExclusiveGroups(Schema, Values, Delimiter) {
     Index := Map()
     for Key, Setting in Schema {

--- a/lib/vim_state.ahk
+++ b/lib/vim_state.ahk
@@ -104,7 +104,7 @@
 
     if(this.StrIsInCurrentVimMode("Visual") or this.StrIsInCurrentVimMode("ydc")){
       SendInput("{Right}")
-      if WinActive("ahk_group VimCursorSameAfterSelect"){
+      if this.Vim.IsConfiguredGroup("VimCursorSameAfterSelect"){
         SendInput("{Left}")
       }
     }


### PR DESCRIPTION
#129 

This PR replaces the hard-coded settings and fixed-size tab-based GUI with a schema-driven architecture and a responsive single-panel interface.

#### Approach

All 30 settings (mode keys, application matching, application behavior groups, and status options) are now declared in a single schema definition (VimSettingSchema.Build()). Each entry carries its default value, type, category, description, and validation constraints. The old AddToConf() calls, the CheckBoxes list, and the block of GroupAdd lines in VimAhk.__New() are removed.

#### New settings GUI

The tab layout is replaced by a single panel with a category filter on the left, a searchable ListView on the right, and a context-sensitive editor below (checkbox for booleans, dropdown for choices, multi-line text for lists). The window is resizable with a minimum size of 520×380. On narrow windows the Import/Export buttons move to a separate row above the action buttons.

Screenshot is here: 

<img width="1176" height="741" alt="image" src="https://github.com/user-attachments/assets/7ddcb992-03a2-45e1-ba6f-505e30b56f1b" />

#### Configurable application behavior groups

The 10 application behavior groups (VimNonEditor, VimLBSelectGroup, VimShiftEnter, VimCtrlEnter, etc.) that were previously hard-coded with GroupAdd are now editable from the GUI. Users can add or remove applications from any group, and changes take effect immediately on Apply without restarting the script. Since AHK does not provide GroupRemove, this is achieved by creating fresh group names with an incrementing suffix on each Setup() call.

#### Exclusive group validation

Settings that conflict with each other are linked through an exclusive group mechanism. Currently VimShiftEnter and VimCtrlEnter share the lineBreakMethod exclusive group. If the same application appears in both, clicking Apply or OK shows an error listing the conflicts. The user resolves them manually before the settings are saved. The same validation runs at startup against values read from the INI file.

#### Startup validation

The initialization path (SetExistValue() → ReadIni() → Setup()) previously accepted any value from the INI without validation. It now runs the same NormalizeValues() and ValidateExclusiveGroups() checks as the GUI before proceeding to SetMenu() and Setup(). Invalid values (wrong type, out of range, exclusive group conflicts) prevent startup.

#### Backward compatibility

The INI file format is unchanged. All default values match the original hard-coded values item by item. The following internal methods on VimAhk are removed as they are replaced by schema operations: AddToConf(), SetConfDefault(), GetDefault(), GetDescription(), GetInfo().