### PR TITLE
feat: schema-driven settings with configurable application groups

### DIFF
--- a/lib/bind/vim_enter_insert.ahk
+++ b/lib/bind/vim_enter_insert.ahk
@@ -23,9 +23,9 @@ a::
 
 o::
 {
-  if WinActive("ahk_group VimShiftEnter"){
+  if Vim.IsConfiguredGroup("VimShiftEnter"){
     SendInput("{End}+{Enter}")
-  } else if WinActive("ahk_group VimCtrlEnter"){
+  } else if Vim.IsConfiguredGroup("VimCtrlEnter"){
     SendInput("{End}^{Enter}")
   } else {
     SendInput("{End}{Enter}")
@@ -35,9 +35,9 @@ o::
 
 +o::
 {
-  if WinActive("ahk_group VimShiftEnter"){
+  if Vim.IsConfiguredGroup("VimShiftEnter"){
     SendInput("{Home}+{Enter}{Left}")
-  } else if WinActive("ahk_group VimCtrlEnter"){
+  } else if Vim.IsConfiguredGroup("VimCtrlEnter"){
     SendInput("{Home}^{Enter}{Left}")
   } else {
     SendInput("{Home}{Enter}{Left}")
@@ -46,7 +46,7 @@ o::
 }
 
 ; Q-dir
-#HotIf Vim.IsVimGroup() and WinActive("ahk_group VimQdir") and (Vim.State.Mode == "Vim_Normal")
+#HotIf Vim.IsVimGroup() and Vim.IsConfiguredGroup("VimQdir") and (Vim.State.Mode == "Vim_Normal")
 ; Enter insert mode to quickly locate the file/folder by using the first letter
 /::Vim.State.SetMode("Insert")
 ; Enter insert mode at rename

--- a/lib/bind/vim_move.ahk
+++ b/lib/bind/vim_move.ahk
@@ -44,7 +44,7 @@ b::Vim.Move.Repeat("b")
 +g::Vim.Move.Move("+g")
 ; Space
 Space::Vim.Move.Repeat("l")
-#HotIf Vim.IsVimGroup() and (Vim.State.StrIsInCurrentVimMode("Vim_")) and not WinActive("ahk_group VimNonEditor")
+#HotIf Vim.IsVimGroup() and (Vim.State.StrIsInCurrentVimMode("Vim_")) and not Vim.IsConfiguredGroup("VimNonEditor")
 ; Enter
 Enter::
 {

--- a/lib/bind/vim_normal.ahk
+++ b/lib/bind/vim_normal.ahk
@@ -44,7 +44,7 @@ u::SendInput("^z")
 }
 
 ; Q-dir
-#HotIf Vim.IsVimGroup() and WinActive("ahk_group VimQdir") and (Vim.State.Mode == "Vim_Normal")
+#HotIf Vim.IsVimGroup() and Vim.IsConfiguredGroup("VimQdir") and (Vim.State.Mode == "Vim_Normal")
 ; For Q-dir, ^X mapping does not work, use !X instead.
 ; ^X does not work to be sent, too, use Down/Up
 ; Switch to left top (1), right top (2), left bottom (3), right bottom (4).

--- a/lib/bind/vim_visual.ahk
+++ b/lib/bind/vim_visual.ahk
@@ -22,7 +22,7 @@ y::
 {
   A_Clipboard := ""
   SendInput("^c{Right}")
-  if WinActive("ahk_group VimCursorSameAfterSelect"){
+  if Vim.IsConfiguredGroup("VimCursorSameAfterSelect"){
     SendInput("{Left}")
   }
   ClipWait(1)

--- a/lib/bind/vim_ydcxp.ahk
+++ b/lib/bind/vim_ydcxp.ahk
@@ -6,11 +6,11 @@ c::Vim.State.SetMode("Vim_ydc_c", 0, -1, 0)
 {
   Vim.State.SetMode("Vim_ydc_y", 0, 0, 1)
   Sleep(150) ; Need to wait (For variable change?)
-  if WinActive("ahk_group VimDoubleHomeGroup"){
+  if Vim.IsConfiguredGroup("VimDoubleHomeGroup"){
     SendInput("{Home}")
   }
   SendInput("{Home}+{End}")
-  if not WinActive("ahk_group VimLBSelectGroup"){
+  if not Vim.IsConfiguredGroup("VimLBSelectGroup"){
     Vim.Move.Move("l")
   }else{
     Vim.Move.Move("")
@@ -21,7 +21,7 @@ c::Vim.State.SetMode("Vim_ydc_c", 0, -1, 0)
 +d::
 {
   Vim.State.SetMode("Vim_ydc_d", 0, 0, 0)
-  if not WinActive("ahk_group VimLBSelectGroup"){
+  if not Vim.IsConfiguredGroup("VimLBSelectGroup"){
     Vim.Move.Move("$")
   }else{
     SendInput("{Shift Down}{End}{Left}")
@@ -32,7 +32,7 @@ c::Vim.State.SetMode("Vim_ydc_c", 0, -1, 0)
 +c::
 {
   Vim.State.SetMode("Vim_ydc_c",0,0,0)
-  if not WinActive("ahk_group VimLBSelectGroup"){
+  if not Vim.IsConfiguredGroup("VimLBSelectGroup"){
     Vim.Move.Move("$")
   }else{
     SendInput("{Shift Down}{End}{Left}")
@@ -88,7 +88,7 @@ p::
   ;  break
   ;}
   if(Vim.State.LineCopy == 1){
-    if WinActive("ahk_group VimNoLBCopyGroup"){
+    if Vim.IsConfiguredGroup("VimNoLBCopyGroup"){
       SendInput("{End}{Enter}^v{Home}")
     }else{
       SendInput("{End}{Enter}^v{BS}{Home}")

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -50,68 +50,13 @@ class VimAhk{
     this.GroupDel := ","
     this.GroupN := 0
     this.GroupName := "VimGroup" this.GroupN
+    this.ConfiguredGroupN := 0
+    this.ConfiguredGroups := Map()
 
     DefaultGroup := this.SetDefaultActiveWindows()
 
-    ; On following applications, Enter works as Enter at the normal mode.
-    ; G sends {End} (not Ctrl+End) to scroll to bottom in these apps.
-    GroupAdd("VimNonEditor", "ahk_exe explorer.exe")  ; Explorer
-    GroupAdd("VimNonEditor", "ahk_exe q-dir_x64.exe") ; Q-dir
-    GroupAdd("VimNonEditor", "ahk_exe q-dir.exe")     ; Q-dir
-    GroupAdd("VimNonEditor", "ahk_exe chrome.exe")    ; Google Chrome
-    GroupAdd("VimNonEditor", "ahk_exe msedge.exe")    ; Microsoft Edge
-    GroupAdd("VimNonEditor", "ahk_exe firefox.exe")   ; Firefox
-    GroupAdd("VimNonEditor", "ahk_exe waterfox.exe")  ; Waterfox
-    GroupAdd("VimNonEditor", "ahk_exe brave.exe")     ; Brave
-    GroupAdd("VimNonEditor", "ahk_exe vivaldi.exe")   ; Vivaldi
-    GroupAdd("VimNonEditor", "ahk_exe opera.exe")     ; Opera
-
-    ; Following applications select the line break at Shift + End.
-    GroupAdd("VimLBSelectGroup", "ahk_exe powerpnt.exe") ; PowerPoint
-    GroupAdd("VimLBSelectGroup", "ahk_exe winword.exe")  ; Word
-    GroupAdd("VimLBSelectGroup", "ahk_exe wordpad.exe")  ; WordPad
-    GroupAdd("VimLBSelectGroup", "ahk_exe notepad.exe")  ; Notepad
-
-    ; Following applications do not copy the line break
-    GroupAdd("VimNoLBCopyGroup", "ahk_exe evernote.exe") ; Evernote
-
-    ; Need Ctrl for Up/Down
-    GroupAdd("VimCtrlUpDownGroup", "ahk_exe onenote.exe") ; OneNote Desktop, before Windows 10
-
-    ; Need Home twice
-    GroupAdd("VimDoubleHomeGroup", "ahk_exe code.exe") ; Visual Studio Code
-
-    ; The following can emulate ^. For others, ^ works the same as 0.
-    ; It does not work for Notepad on Windows 11.
-    ; GroupAdd("VimCaretMove", "ahk_exe notepad.exe") ; Notepad
-
-    ; The following start cursor from the same place after selection.
-    ; Others start right/left (by cursor) point of the selection
-    GroupAdd("VimCursorSameAfterSelect", "ahk_exe notepad.exe") ; Notepad
-    GroupAdd("VimCursorSameAfterSelect", "ahk_exe explorer.exe") ; Explorer
-
-    ; Q-Dir
-    GroupAdd("VimQdir", "ahk_exe q-dir_x64.exe") ; q-dir
-    GroupAdd("VimQdir", "ahk_exe q-dir.exe") ; q-dir
-
-    ; Shift-Enter to insert line break in these applications
-    GroupAdd("VimShiftEnter", "ahk_exe ChatGPT.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Claude.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Cursor.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe slack.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe ms-teams.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Teams.exe") ; Old version
-    GroupAdd("VimShiftEnter", "ahk_exe Discord.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe WhatsApp.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe Zoom.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe PhoneExperienceHost.exe") ;
-    GroupAdd("VimShiftEnter", "ahk_exe LINE.exe") ;
-
-    ; Control-Enter to insert line break in these applications
-    ;GroupAdd("VimCtrlEnter", "...") ;
-
     ; Configuration values for Read/Write ini
-    this.Conf := VimSettingSchema.Build(DefaultGroup)
+    this.Conf := VimSettingSchema.Build(DefaultGroup, this.GroupDel)
 
     this.CheckBoxes := ["VimEscNormal", "VimEscNormalDirect", "VimSendEscNormal", "VimLongEscNormal", "VimCtrlBracketToEsc", "VimCtrlBracketNormal", "VimCtrlBracketNormalDirect", "VimSendCtrlBracketNormal", "VimLongCtrlBracketNormal", "VimRestoreIME", "VimJJ", "VimChangeCaretWidth"]
 
@@ -143,6 +88,7 @@ class VimAhk{
   }
 
   SetValues(Values){
+    VimSettingSchema.ValidateExclusiveGroups(this.Conf, Values, this.GroupDel)
     for Key, Value in Values {
       this.Conf[Key]["val"] := Value
     }
@@ -160,6 +106,33 @@ class VimAhk{
     return this.GetConf(Key, "info")
   }
 
+  ; AutoHotkey can only append rules to window groups; existing rules cannot be cleared.
+  ; Whenever settings are applied, new groups are built before the current mapping is replaced.
+  ; Old groups remain until the script exits and are no longer queried.
+  SetConfiguredGroups(){
+    this.ConfiguredGroupN++
+    Groups := Map()
+    for , Setting in this.Conf {
+      Group := Setting["group"]
+      if (Group == "") {
+        continue
+      }
+      GroupName := Group "_" this.ConfiguredGroupN
+      Groups[Group] := GroupName
+      Loop Parse, Setting["val"], this.GroupDel {
+        if (A_LoopField != "") {
+          GroupAdd(GroupName, A_LoopField)
+        }
+      }
+    }
+    this.ConfiguredGroups := Groups
+  }
+
+  IsConfiguredGroup(Group){
+    return this.ConfiguredGroups.Has(Group)
+      and WinActive("ahk_group " this.ConfiguredGroups[Group])
+  }
+
   SetGroup(){
     this.GroupN++
     this.GroupName := "VimGroup" this.GroupN
@@ -173,6 +146,7 @@ class VimAhk{
   Setup(){
     SetTitleMatchMode(this.GetVal("VimSetTitleMatchMode"))
     SetTitleMatchMode(this.GetVal("VimSetTitleMatchModeFS"))
+    this.SetConfiguredGroups()
     this.State.SetStatusCheck()
     this.SetGroup()
     this.VimHotkey.Set()

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -11,6 +11,7 @@
 #Include %A_LineFile%\..\vim_ini.ahk
 #Include %A_LineFile%\..\vim_menu.ahk
 #Include %A_LineFile%\..\vim_move.ahk
+#Include %A_LineFile%\..\vim_setting_schema.ahk
 #Include %A_LineFile%\..\vim_setting.ahk
 #Include %A_LineFile%\..\vim_state.ahk
 #Include %A_LineFile%\..\vim_tooltip.ahk
@@ -110,77 +111,12 @@ class VimAhk{
     ;GroupAdd("VimCtrlEnter", "...") ;
 
     ; Configuration values for Read/Write ini
-    ; setting, default, val, description, info
-    this.Conf := Map()
-    this.AddToConf("VimEscNormal", 1, 1
-      , "ESC to enter the normal mode"
-      , "If checked, pressing ESC enters normal mode.")
-    this.AddToConf("VimEscNormalDirect", 1, 1
-      , "ESC to enter the normal mode directly even if converting in IME"
-      , "If checked, ESC enters normal mode even while IME is converting.`nIf not checked, ESC behaves as normal ESC while IME is converting.")
-    this.AddToConf("VimSendEscNormal", 0, 0
-      , "Send ESC by ESC at the normal mode"
-      , "If checked, a short ESC press sends ESC in normal mode.`nEnable ESC to enter normal mode first.")
-    this.AddToConf("VimLongEscNormal", 0, 0
-      , "Long press ESC to enter the normal mode"
-      , "If checked, short and long press behavior of ESC is swapped.`nEnable ESC to enter normal mode first.")
-    this.AddToConf("VimCtrlBracketToEsc", 1, 1
-      , "Ctrl-[ to ESC"
-      , "If checked, Ctrl-[ behaves as ESC.`nIf Ctrl-[ to normal mode is disabled, Ctrl-[ always sends ESC.`nIf both are checked, long press Ctrl-[ sends ESC.")
-    this.AddToConf("VimCtrlBracketNormal", 1, 1
-      , "Ctrl-[ to enter the normal mode"
-      , "If checked, pressing Ctrl-[ enters normal mode.")
-    this.AddToConf("VimCtrlBracketNormalDirect", 1, 1
-      , "Ctrl-[ to enter the normal mode directly even if converting in IME"
-      , "If checked, Ctrl-[ enters normal mode even while IME is converting.`nIf not checked, Ctrl-[ behaves as ESC while IME is converting.")
-    this.AddToConf("VimSendCtrlBracketNormal", 0, 0
-      , "Send Ctrl-[ by Ctrl-[ at the normal mode"
-      , "If checked, a short Ctrl-[ press sends Ctrl-[ in normal mode.`nEnable Ctrl-[ to enter normal mode first.")
-    this.AddToConf("VimLongCtrlBracketNormal", 0, 0
-      , "Long press Ctrl-[ to enter the normal mode"
-      , "If checked, short and long press behavior of Ctrl-[ is swapped.`nEnable Ctrl-[ to enter normal mode first.")
-    this.AddToConf("VimChangeCaretWidth", 0, 0
-      , "Change to thick text caret when in normal mode"
-      , "If checked, caret width changes by mode (thick in normal/visual, thin in insert).`nIt may not work in all applications and can briefly change window focus.")
-    this.AddToConf("VimRestoreIME", 1, 1
-      , "Restore IME status at entering the insert mode"
-      , "If checked, IME status is saved in insert mode and restored when returning to insert mode.")
-    this.AddToConf("VimJJ", 0, 0
-      , "JJ to enter the normal mode"
-      , "If checked, `jj` enters normal mode from insert mode.")
-    this.AddToConf("VimTwoLetter", "", ""
-      , "Two-letter to enter the normal mode"
-      , "Two-letter mappings to enter normal mode from insert mode.`nSet one pair per line.`nEach pair must be exactly two different letters.")
-    this.AddToConf("VimDisableUnused", 1, 1
-      , "Disable unused keys in the normal mode"
-      , "Disable level for unused keys outside insert mode:`n1: Do not disable unused keys`n2: Disable alphabets (+Shift) and symbols`n3: Disable all, including modified keys (e.g. Ctrl+Z)")
-    this.AddToConf("VimSetTitleMatchMode", "2", "2"
-      , "SetTitleMatchMode"
-      , "SetTitleMatchMode mode:`n1: Start with`n2: Contain`n3: Exact match`nRegEx: Regular expression")
-    this.AddToConf("VimSetTitleMatchModeFS", "Fast", "Fast"
-      , "SetTitleMatchMode"
-      , "SetTitleMatchMode speed:`nFast: Text is not detected for some edit controls`nSlow: Works for all windows, but slower")
-    this.AddToConf("VimIconCheckInterval", 1000, 1000
-      , "Icon check interval (ms)"
-      , "Interval (ms) to check vim_ahk status and update tray icon.`nIf set to 0, the original AHK icon is used.")
-    this.AddToConf("VimVerbose", 1, 1
-      , "Verbose level"
-      , "Verbose level:`n1: No output`n2: Minimum tooltip (mode only)`n3: Tooltip (all information)`n4: Debug message box (does not auto-close)")
-    this.AddToConf("VimAppList", "Allow List", "Allow List"
-      , "Application list usage"
-      , "Application list mode:`nAll: Enable vim_ahk on all applications (ignore the list)`nAllow List: Use list as allow list`nDeny List: Use list as deny list")
-    this.AddToConf("VimGroup", DefaultGroup, DefaultGroup
-      , "Application list"
-      , "Applications where vim_ahk is enabled.`nSet one application per line.`nEach line can be Window Title, Class, or Process.")
+    this.Conf := VimSettingSchema.Build(DefaultGroup)
 
     this.CheckBoxes := ["VimEscNormal", "VimEscNormalDirect", "VimSendEscNormal", "VimLongEscNormal", "VimCtrlBracketToEsc", "VimCtrlBracketNormal", "VimCtrlBracketNormalDirect", "VimSendCtrlBracketNormal", "VimLongCtrlBracketNormal", "VimRestoreIME", "VimJJ", "VimChangeCaretWidth"]
 
     ; Initialize
     this.Initialize()
-  }
-
-  AddToConf(setting, default, val, description, info){
-    this.Conf[setting] :=  Map("default", default, "val", val, "description", description, "info", info)
   }
 
   SetConfDefault(){
@@ -204,6 +140,12 @@ class VimAhk{
 
   GetVal(Key){
     return this.GetConf(Key, "val")
+  }
+
+  SetValues(Values){
+    for Key, Value in Values {
+      this.Conf[Key]["val"] := Value
+    }
   }
 
   GetDefault(Key){
@@ -240,6 +182,9 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
+    Values := VimSettingSchema.NormalizeValues(
+      this.Conf, VimSettingSchema.Values(this.Conf), this.GroupDel)
+    this.SetValues(Values)
     this.VimMenu.SetMenu()
     this.Setup()
   }

--- a/lib/vim_move.ahk
+++ b/lib/vim_move.ahk
@@ -82,7 +82,7 @@
   }
 
   Zero(){
-    if WinActive("ahk_group VimDoubleHomeGroup"){
+    if this.Vim.IsConfiguredGroup("VimDoubleHomeGroup"){
       SendInput("{Home}")
     }
     SendInput("{Home}")
@@ -90,7 +90,7 @@
 
   Up(n:=1){
     Loop n {
-      if WinActive("ahk_group VimCtrlUpDownGroup"){
+      if this.Vim.IsConfiguredGroup("VimCtrlUpDownGroup"){
         SendInput("^{Up}")
       } else {
         SendInput("{Up}")
@@ -100,7 +100,7 @@
 
   Down(n:=1){
     Loop n {
-      if WinActive("ahk_group VimCtrlUpDownGroup"){
+      if this.Vim.IsConfiguredGroup("VimCtrlUpDownGroup"){
         SendInput("^{Down}")
       } else {
         SendInput("{Down}")
@@ -121,14 +121,14 @@
 
       ; 1 character
       if(Key == "h"){
-        if WinActive("ahk_group VimQdir"){
+        if this.Vim.IsConfiguredGroup("VimQdir"){
           SendInput("{BackSpace}")
         }
         else {
           SendInput("{Left}")
         }
       }else if(Key == "l"){
-        if WinActive("ahk_group VimQdir"){
+        if this.Vim.IsConfiguredGroup("VimQdir"){
           SendInput("{Enter}")
         }
         else {
@@ -145,13 +145,13 @@
         }
       }else if(Key == "^"){
         if(this.shift == 1){
-          if WinActive("ahk_group VimCaretMove"){
+          if this.Vim.IsConfiguredGroup("VimCaretMove"){
             SendInput("+{Home}+^{Right}+^{Left}")
           }else{
             SendInput("+{Home}")
           }
         }else{
-          if WinActive("ahk_group VimCaretMove"){
+          if this.Vim.IsConfiguredGroup("VimCaretMove"){
             SendInput("{Home}^{Right}^{Left}")
           }else{
             this.Zero()
@@ -202,7 +202,7 @@
     }else if(Key == "g"){
       SendInput("^{Home}")
     }else if(Key == "+g"){
-      if WinActive("ahk_group VimNonEditor"){
+      if this.Vim.IsConfiguredGroup("VimNonEditor"){
         SendInput("{End}")
       } else {
         SendInput("^{End}{Home}")
@@ -234,7 +234,7 @@
     }
     this.Down(this.Vim.State.n - 1)
     SendInput("{End}")
-    if not WinActive("ahk_group VimLBSelectGroup"){
+    if not this.Vim.IsConfiguredGroup("VimLBSelectGroup"){
       this.Move("l")
     }else{
       this.Move("")

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -159,8 +159,8 @@ class VimSetting Extends VimGui{
     try {
       this.Obj.Submit(false)
       this.VimV2Conf()
-      this.Vim.Ini.WriteIni()
       this.Vim.Setup()
+      this.Vim.Ini.WriteIni()
       this.Hide(Obj)
     } catch as e {
       MsgBox(e.Message, "Vim Ahk", "Iconx")
@@ -171,8 +171,8 @@ class VimSetting Extends VimGui{
     try {
       this.Obj.Submit(false)
       this.VimV2Conf()
-      this.Vim.Ini.WriteIni()
       this.Vim.Setup()
+      this.Vim.Ini.WriteIni()
       this.Vim.VimToolTip.RemoveToolTip()
     } catch as e {
       MsgBox(e.Message, "Vim Ahk", "Iconx")
@@ -223,8 +223,8 @@ class VimSetting Extends VimGui{
       ; Ensure current settings are saved before export
       this.Obj.Submit(false)
       this.VimV2Conf()
-      this.Vim.Ini.WriteIni()
       this.Vim.Setup()
+      this.Vim.Ini.WriteIni()
       FileCopy(this.Vim.Ini.Ini, path, true)
       MsgBox("Exported settings to: `n" path, "Vim Ahk")
     } catch as e {

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -1,4 +1,5 @@
 #Include %A_LineFile%\..\vim_gui.ahk
+#Include %A_LineFile%\..\vim_setting_application_panel.ahk
 
 
 class VimSetting Extends VimGui{
@@ -63,17 +64,9 @@ class VimSetting Extends VimGui{
     this.AddConf("DDL", "VimSetTitleMatchModeFS", "X+5 YP+0 W50 Choose" matchmodefs, ["Fast", "Slow"], True)
 
     ; Applications specific
-    this.AddConf("Text", "VimAppList", "XS+10 Y+15")
-    if(this.Vim.GetVal("VimAppList") == "All"){
-      matchapplist := 1
-    }else if(this.Vim.GetVal("VimAppList") == "Allow List"){
-      matchapplist := 2
-    }else{
-      matchapplist := 3
-    }
-    this.AddConf("DDL", "VimAppList", "X+5 YP-4 W100 Choose" matchapplist, ["All", "Allow List", "Deny List"], True)
-    this.AddConf("Text", "VimGroup", "XS+10 Y+5")
-    this.AddConf("Edit", "VimGroup", "XS+10 Y+5 R10 W300 Multi", StrReplace(this.Vim.GetVal("VimGroup"), this.Vim.GroupDel, "`n", 0, , -1), True)
+    this.ApplicationPanel := VimSettingApplicationPanel(
+      this.Obj, this.Vim.Conf, this.Vim.GroupDel
+      , ObjBindMethod(this.Vim, "AddToolTip"))
 
     ; Tab 3: Status
     this.Tab.UseTab(3)
@@ -119,93 +112,71 @@ class VimSetting Extends VimGui{
     this.UpdateGuiValue()
   }
 
-  UpdateGuiValue(){
-    for i, k in this.Vim.CheckBoxes {
-      this.Obj[k].Value := this.Vim.GetVal(k)
+  UpdateGuiValue(Values := 0){
+    if !(Values is Map) {
+      Values := VimSettingSchema.Values(this.Vim.Conf)
     }
-    this.Obj["VimTwoLetter"].Value := StrReplace(this.Vim.GetVal("VimTwoLetter"), this.Vim.GroupDel, "`n", 0, , -1)
-    this.Obj["VimDisableUnused"].Value := this.Vim.GetVal("VimDisableUnused")
-    this.Obj["VimIconCheckInterval"].Value := this.Vim.GetVal("VimIconCheckInterval")
-    if(this.Vim.GetVal("VimSetTitleMatchMode") == "RegEx"){
+    for i, k in this.Vim.CheckBoxes {
+      this.Obj[k].Value := Values[k]
+    }
+    this.Obj["VimTwoLetter"].Value := StrReplace(Values["VimTwoLetter"], this.Vim.GroupDel, "`n", 0, , -1)
+    this.Obj["VimDisableUnused"].Value := Values["VimDisableUnused"]
+    this.Obj["VimIconCheckInterval"].Value := Values["VimIconCheckInterval"]
+    if(Values["VimSetTitleMatchMode"] == "RegEx"){
       matchmode := 4
     }else{
-      matchmode := this.Vim.GetVal("VimSetTitleMatchMode")
+      matchmode := Values["VimSetTitleMatchMode"]
     }
     this.Obj["VimSetTitleMatchMode"].Value := matchmode
-    if(this.Vim.GetVal("VimSetTitleMatchModeFS") == "Fast"){
+    if(Values["VimSetTitleMatchModeFS"] == "Fast"){
       matchmodefs := 1
     }else{
       matchmodefs := 2
     }
     this.Obj["VimSetTitleMatchModeFS"].Value := matchmodefs
-    this.Obj["VimVerbose"].Value := this.Vim.GetVal("VimVerbose")
-    if(this.Vim.GetVal("VimAppList") == "All"){
-      matchapplist := 1
-    }else if(this.Vim.GetVal("VimAppList") == "Allow List"){
-      matchapplist := 2
-    }else{
-      matchapplist := 3
-    }
-    this.Obj["VimAppList"].Value := matchapplist
-    this.Obj["VimGroup"].Value := StrReplace(this.Vim.GetVal("VimGroup"), this.Vim.GroupDel, "`n", 0, , -1)
+    this.Obj["VimVerbose"].Value := Values["VimVerbose"]
+    this.ApplicationPanel.LoadValues(Values)
   }
 
   VimV2Conf(){
-    for k, v in this.Vim.Conf {
-      if(k == "VimGroup" || k == "VimTwoLetter"){
-        v["val"] := this.VimParseList(this.Obj[k].Value)
-      }else if(k == "VimSetTitleMatchMode" && this.Obj[k].Value == 4){
-        v["val"] := "RegEx"
-      }else if(k == "VimSetTitleMatchModeFS"){
-        if(this.Obj[k].Value == 1){
-          v["val"] := "Fast"
-        }else{
-          v["val"] := "Slow"
-        }
-      }else if(k == "VimAppList"){
-        if(this.Obj[k].Value == 1){
-          v["val"] := "All"
-        }else if(this.Obj[k].Value == 2){
-          v["val"] := "Allow List"
-        }else{
-          v["val"] := "Deny List"
-        }
-      }else{
-        v["val"] := this.Obj[k].Value
-      }
+    Values := VimSettingSchema.Values(this.Vim.Conf)
+    for i, k in this.Vim.CheckBoxes {
+      Values[k] := this.Obj[k].Value
     }
-  }
-
-  VimParseList(List){
-    result := ""
-    tmpArray := []
-    Loop Parse, List, "`n" {
-      if(! tmpArray.Has(A_LoopField)){
-        tmpArray.push(A_LoopField)
-        if(result == ""){
-          result := A_LoopField
-        }else{
-          result := result this.Vim.GroupDel A_LoopField
-        }
-      }
-    }
-    return result
+    Values["VimTwoLetter"] := this.Obj["VimTwoLetter"].Value
+    Values["VimDisableUnused"] := this.Obj["VimDisableUnused"].Text
+    Values["VimIconCheckInterval"] := this.Obj["VimIconCheckInterval"].Value
+    Values["VimSetTitleMatchMode"] := this.Obj["VimSetTitleMatchMode"].Text
+    Values["VimSetTitleMatchModeFS"] := this.Obj["VimSetTitleMatchModeFS"].Text
+    Values["VimVerbose"] := this.Obj["VimVerbose"].Text
+    this.ApplicationPanel.StoreValues(Values)
+    Values := VimSettingSchema.NormalizeValues(
+      this.Vim.Conf, Values, this.Vim.GroupDel)
+    this.Vim.SetValues(Values)
   }
 
   OK(Obj, Info){
-    this.Obj.Submit()
-    this.VimV2Conf()
-    this.Vim.Setup()
-    this.Vim.Ini.WriteIni()
-    this.Hide(Obj)
+    try {
+      this.Obj.Submit(false)
+      this.VimV2Conf()
+      this.Vim.Ini.WriteIni()
+      this.Vim.Setup()
+      this.Hide(Obj)
+    } catch as e {
+      MsgBox(e.Message, "Vim Ahk", "Iconx")
+    }
   }
 
   Apply(Obj, Info){
-    this.Obj.Submit(false)
-    this.VimV2Conf()
-    this.Vim.Setup()
-    this.Vim.Ini.WriteIni()
-    this.Vim.VimToolTip.RemoveToolTip()
+    try {
+      this.Obj.Submit(false)
+      this.VimV2Conf()
+      this.Vim.Ini.WriteIni()
+      this.Vim.Setup()
+      this.Vim.VimToolTip.RemoveToolTip()
+    } catch as e {
+      MsgBox(e.Message, "Vim Ahk", "Iconx")
+    }
   }
 
   Cancel(Obj, Info){
@@ -213,8 +184,7 @@ class VimSetting Extends VimGui{
   }
 
   Reset(Obj, Info){
-    this.Vim.SetConfDefault()
-    this.UpdateGuiValue()
+    this.UpdateGuiValue(VimSettingSchema.Values(this.Vim.Conf, True))
   }
 
   ImportIni(Obj, Info){
@@ -233,35 +203,10 @@ class VimSetting Extends VimGui{
       tmpIni.ReadIni()
 
       ; Update GUI controls from tmpConf only
-      ; CheckBoxes
-      for i, k in this.Vim.CheckBoxes {
-        if this.Obj.HasProp(k) && tmpConf.Has(k)
-          this.Obj[k].Value := tmpConf[k]["val"]
-      }
-      ; Text/DDL fields with conversions
-      if this.Obj.HasProp("VimTwoLetter")
-        this.Obj["VimTwoLetter"].Value := StrReplace(tmpConf["VimTwoLetter"]["val"], this.Vim.GroupDel, "`n", 0, , -1)
-      if this.Obj.HasProp("VimDisableUnused")
-        this.Obj["VimDisableUnused"].Value := tmpConf["VimDisableUnused"]["val"]
-      if this.Obj.HasProp("VimIconCheckInterval")
-        this.Obj["VimIconCheckInterval"].Value := tmpConf["VimIconCheckInterval"]["val"]
-      ; Title match mode
-      if this.Obj.HasProp("VimSetTitleMatchMode") {
-        matchmode := tmpConf["VimSetTitleMatchMode"]["val"]
-        this.Obj["VimSetTitleMatchMode"].Value := (matchmode == "RegEx") ? 4 : matchmode
-      }
-      if this.Obj.HasProp("VimSetTitleMatchModeFS") {
-        matchmodefs := tmpConf["VimSetTitleMatchModeFS"]["val"]
-        this.Obj["VimSetTitleMatchModeFS"].Value := (matchmodefs == "Fast") ? 1 : 2
-      }
-      if this.Obj.HasProp("VimVerbose")
-        this.Obj["VimVerbose"].Value := tmpConf["VimVerbose"]["val"]
-      if this.Obj.HasProp("VimAppList") {
-        ap := tmpConf["VimAppList"]["val"]
-        this.Obj["VimAppList"].Value := (ap == "All") ? 1 : (ap == "Allow List") ? 2 : 3
-      }
-      if this.Obj.HasProp("VimGroup")
-        this.Obj["VimGroup"].Value := StrReplace(tmpConf["VimGroup"]["val"], this.Vim.GroupDel, "`n", 0, , -1)
+      Values := VimSettingSchema.Values(tmpConf)
+      Values := VimSettingSchema.NormalizeValues(
+        this.Vim.Conf, Values, this.Vim.GroupDel)
+      this.UpdateGuiValue(Values)
 
       ; Do not write to the main INI nor apply runtime yet — waits for Apply
       MsgBox("Imported settings staged from:`n" path "`nClick Apply to apply them.", "Vim Ahk")
@@ -279,6 +224,7 @@ class VimSetting Extends VimGui{
       this.Obj.Submit(false)
       this.VimV2Conf()
       this.Vim.Ini.WriteIni()
+      this.Vim.Setup()
       FileCopy(this.Vim.Ini.Ini, path, true)
       MsgBox("Exported settings to: `n" path, "Vim Ahk")
     } catch as e {

--- a/lib/vim_setting_application_panel.ahk
+++ b/lib/vim_setting_application_panel.ahk
@@ -1,0 +1,162 @@
+#Include %A_LineFile%\..\vim_setting_schema.ahk
+
+
+; Shared editor for VimGroup and schema-defined application behavior groups.
+; The other settings tabs continue to use their original controls in VimSetting.
+class VimSettingApplicationPanel {
+  static MainGroupKey := "VimGroup"
+  static AppListKey := "VimAppList"
+
+  __New(GuiObj, Schema, Delimiter, AddToolTipFn) {
+    this.Gui := GuiObj
+    this.Schema := Schema
+    this.Delimiter := Delimiter
+    this.AddToolTipFn := AddToolTipFn
+    this.Values := Map()
+    this.GroupKeys := []
+    this.CurrentGroupKey := ""
+    this.Loading := False
+
+    this.ApplicationGroupLabel := this.AddLabel(
+      "XS+10 Y+15", "Application group")
+    this.ApplicationGroup := this.Gui.Add(
+      "DropDownList", "X+5 YP-4 W260")
+    this.LoadApplicationGroups()
+
+    AppListSetting := this.Schema[VimSettingApplicationPanel.AppListKey]
+    this.AppListLabel := this.AddLabel(
+      "XS+10 Y+12", AppListSetting["description"], AppListSetting["info"])
+    this.AppList := this.Gui.Add("DropDownList", "X+5 YP-4 W120")
+    this.AppList.Add(AppListSetting["choices"])
+    this.AddToolTip(this.AppList, AppListSetting["info"])
+
+    this.GroupEditor := this.Gui.Add(
+      "Edit", "XS+10 Y+10 R8 W430 Multi VScroll WantTab")
+    this.GroupInfo := this.AddLabel("XS+10 Y+8 W430 H48", "")
+    this.ApplicationGroup.OnEvent(
+      "Change", ObjBindMethod(this, "ApplicationGroupChanged"))
+
+    this.LoadValues(VimSettingSchema.Values(this.Schema))
+  }
+
+  AddLabel(Options, Text, ToolTipText := "") {
+    Control := this.Gui.Add("Text", Options, Text)
+    ; Pseudo click event to show the tooltip, as used by the original settings GUI.
+    Control.OnEvent("Click", DoNothing(Obj, Info) => "")
+    if (ToolTipText != "") {
+      this.AddToolTip(Control, ToolTipText)
+    }
+    return Control
+  }
+
+  AddToolTip(Control, Text) {
+    this.AddToolTipFn.Call(Control.Hwnd, Text)
+  }
+
+  LoadApplicationGroups() {
+    MainGroupKey := VimSettingApplicationPanel.MainGroupKey
+    if !this.Schema.Has(MainGroupKey) {
+      throw ValueError("Missing application group setting: " MainGroupKey)
+    }
+
+    this.GroupKeys.Push(MainGroupKey)
+    Labels := [this.Schema[MainGroupKey]["description"]]
+    for Key, Setting in this.Schema {
+      if (Setting["group"] == "") {
+        continue
+      }
+      Label := Setting["label"]
+      if (Label == "") {
+        throw ValueError("Missing application group label: " Key)
+      }
+      this.GroupKeys.Push(Key)
+      Labels.Push(Label)
+    }
+    this.ApplicationGroup.Add(Labels)
+  }
+
+  ApplicationGroupChanged(Control, Info) {
+    if this.Loading {
+      return
+    }
+    this.SaveCurrentGroup()
+    Index := Control.Value
+    if (Index < 1 || Index > this.GroupKeys.Length) {
+      throw ValueError("Invalid application group selection.")
+    }
+    this.ShowGroup(this.GroupKeys[Index])
+  }
+
+  SaveCurrentGroup() {
+    if (this.CurrentGroupKey == "") {
+      return
+    }
+    this.Values[this.CurrentGroupKey] := VimSettingSchema.NormalizeList(
+      this.GroupEditor.Text, this.Delimiter)
+  }
+
+  ShowGroup(Key) {
+    Setting := this.Schema[Key]
+    this.CurrentGroupKey := Key
+    this.GroupEditor.Text := StrReplace(
+      this.Values[Key], this.Delimiter, "`r`n")
+    this.GroupInfo.Text := Setting["info"]
+
+    ShowAppList := Key == VimSettingApplicationPanel.MainGroupKey
+    this.AppListLabel.Visible := ShowAppList
+    this.AppList.Visible := ShowAppList
+
+    for Control in [this.ApplicationGroupLabel, this.ApplicationGroup
+        , this.GroupEditor, this.GroupInfo] {
+      this.AddToolTip(Control, Setting["info"])
+    }
+  }
+
+  LoadValues(Values) {
+    this.Loading := True
+    try {
+      for Key in this.GroupKeys {
+        this.Values[Key] := Values[Key]
+      }
+
+      AppListSetting := this.Schema[VimSettingApplicationPanel.AppListKey]
+      this.AppList.Choose(this.ChoiceIndex(
+        AppListSetting, Values[VimSettingApplicationPanel.AppListKey]))
+
+      GroupKey := this.CurrentGroupKey
+      if (GroupKey == "") {
+        GroupKey := this.GroupKeys[1]
+      }
+      this.ApplicationGroup.Choose(this.GroupIndex(GroupKey))
+      this.ShowGroup(GroupKey)
+    } finally {
+      this.Loading := False
+    }
+  }
+
+  StoreValues(Values) {
+    this.SaveCurrentGroup()
+    for Key in this.GroupKeys {
+      Values[Key] := this.Values[Key]
+    }
+    Values[VimSettingApplicationPanel.AppListKey] := this.AppList.Text
+  }
+
+  ChoiceIndex(Setting, Value) {
+    for Index, Choice in Setting["choices"] {
+      if (Choice == Value) {
+        return Index
+      }
+    }
+    throw ValueError(Setting["description"] " has an invalid value.")
+  }
+
+  GroupIndex(Key) {
+    for Index, GroupKey in this.GroupKeys {
+      if (GroupKey == Key) {
+        return Index
+      }
+    }
+    throw ValueError("Unknown application group: " Key)
+  }
+}

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -1,5 +1,5 @@
 class VimSettingSchema {
-  static Build(DefaultGroup) {
+  static Build(DefaultGroup, Delimiter := ",") {
     Schema := Map()
 
     this.Add(Schema, "VimEscNormal", 1, "Mode keys", "boolean"
@@ -72,13 +72,96 @@ class VimSettingSchema {
       , "Application list"
       , "Applications where vim_ahk is enabled.`nSet one application per line.`nEach line can be Window Title, Class, or Process.")
 
+    this.AddApplicationGroup(Schema, "VimNonEditor"
+      , ["ahk_exe explorer.exe", "ahk_exe q-dir_x64.exe", "ahk_exe q-dir.exe"
+        , "ahk_exe chrome.exe", "ahk_exe msedge.exe", "ahk_exe firefox.exe"
+        , "ahk_exe waterfox.exe", "ahk_exe brave.exe", "ahk_exe vivaldi.exe"
+        , "ahk_exe opera.exe"]
+      , "Non-editor"
+      , "Non-editor applications"
+      , "Enter keeps its native behavior in normal mode, and G sends End in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimLBSelectGroup"
+      , ["ahk_exe powerpnt.exe", "ahk_exe winword.exe", "ahk_exe wordpad.exe", "ahk_exe notepad.exe"]
+      , "Select line breaks"
+      , "Applications that select line breaks"
+      , "Shift+End includes the line break in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimNoLBCopyGroup"
+      , ["ahk_exe evernote.exe"]
+      , "Omit copied line breaks"
+      , "Applications that omit copied line breaks"
+      , "Line-wise copy omits the line break in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCtrlUpDownGroup"
+      , ["ahk_exe onenote.exe"]
+      , "Ctrl+Up/Down"
+      , "Applications requiring Ctrl+Up and Ctrl+Down"
+      , "Vertical paragraph movement uses Ctrl+Up and Ctrl+Down in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimDoubleHomeGroup"
+      , ["ahk_exe code.exe"]
+      , "Double Home"
+      , "Applications requiring Home twice"
+      , "Line-start movement sends Home twice in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCaretMove", []
+      , "Caret movement"
+      , "Applications supporting caret movement"
+      , "The ^ command moves to the first non-whitespace character in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimCursorSameAfterSelect"
+      , ["ahk_exe notepad.exe", "ahk_exe explorer.exe"]
+      , "Cursor after select"
+      , "Applications preserving the cursor after selection"
+      , "The cursor starts from the same position after selection in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimQdir"
+      , ["ahk_exe q-dir_x64.exe", "ahk_exe q-dir.exe"]
+      , "Q-Dir"
+      , "Q-Dir applications"
+      , "Q-Dir-specific normal-mode bindings are active in these applications."
+      , Delimiter)
+    this.AddApplicationGroup(Schema, "VimShiftEnter"
+      , ["ahk_exe ChatGPT.exe", "ahk_exe Claude.exe", "ahk_exe Cursor.exe"
+        , "ahk_exe slack.exe", "ahk_exe ms-teams.exe", "ahk_exe Teams.exe"
+        , "ahk_exe Discord.exe", "ahk_exe WhatsApp.exe", "ahk_exe Zoom.exe"
+        , "ahk_exe PhoneExperienceHost.exe", "ahk_exe LINE.exe"]
+      , "Shift+Enter line break"
+      , "Applications using Shift+Enter for line breaks"
+      , "The o and O commands send Shift+Enter in these applications."
+      , Delimiter, ["lineBreakMethod"])
+    this.AddApplicationGroup(Schema, "VimCtrlEnter", []
+      , "Ctrl+Enter line break"
+      , "Applications using Ctrl+Enter for line breaks"
+      , "The o and O commands send Ctrl+Enter in these applications."
+      , Delimiter, ["lineBreakMethod"])
+
     return Schema
   }
 
+  static AddApplicationGroup(Schema, Key, Items, Label, Description, Info, Delimiter
+      , ExclusiveGroups := 0) {
+    this.Add(Schema, Key, this.Join(Items, Delimiter), "Application behavior", "list"
+      , Description, Info, 0, "", "", Key, ExclusiveGroups, Label)
+  }
+
+  static Join(Items, Delimiter) {
+    Result := ""
+    for Item in Items {
+      Result .= (Result == "" ? "" : Delimiter) Item
+    }
+    return Result
+  }
+
   static Add(Schema, Key, Default, Category, Kind, Description, Info
-      , Choices := 0, Min := "", Max := "") {
+      , Choices := 0, Min := "", Max := "", Group := "", ExclusiveGroups := 0
+      , Label := "") {
     if !(Choices is Array) {
       Choices := []
+    }
+    if !(ExclusiveGroups is Array) {
+      ExclusiveGroups := []
     }
     Schema[Key] := Map(
       "default", Default,
@@ -89,7 +172,10 @@ class VimSettingSchema {
       "info", Info,
       "choices", Choices,
       "min", Min,
-      "max", Max)
+      "max", Max,
+      "group", Group,
+      "exclusiveGroups", ExclusiveGroups,
+      "label", Label)
   }
 
   static Values(Schema, Defaults := False) {
@@ -107,6 +193,48 @@ class VimSettingSchema {
       Normalized[Key] := this.Normalize(Setting, Values[Key], Delimiter)
     }
     return Normalized
+  }
+
+  static ValidateExclusiveGroups(Schema, Values, Delimiter) {
+    Index := Map()
+    for Key, Setting in Schema {
+      for Group in Setting["exclusiveGroups"] {
+        if !Index.Has(Group) {
+          Index[Group] := Map()
+        }
+        Items := Index[Group]
+        Loop Parse, Values[Key], Delimiter {
+          if (A_LoopField == "") {
+            continue
+          }
+          ItemKey := StrLower(A_LoopField)
+          if !Items.Has(ItemKey) {
+            Items[ItemKey] := Map("value", A_LoopField, "owners", Map())
+          }
+          Items[ItemKey]["owners"][Key] := True
+        }
+      }
+    }
+
+    Conflicts := ""
+    for Group, Items in Index {
+      for , Item in Items {
+        if (Item["owners"].Count < 2) {
+          continue
+        }
+        Owners := ""
+        for Key in Item["owners"] {
+          Owners .= (Owners == "" ? "" : ", ") Schema[Key]["description"]
+        }
+        Conflicts .= (Conflicts == "" ? "" : "`n`n")
+          . Group ":`n" Item["value"] "`n" Owners
+      }
+    }
+
+    if (Conflicts != "") {
+      throw ValueError("Each item can belong to one setting in an exclusive group.`n`n"
+        . Conflicts)
+    }
   }
 
   static Normalize(Setting, Value, Delimiter) {

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -1,0 +1,159 @@
+class VimSettingSchema {
+  static Build(DefaultGroup) {
+    Schema := Map()
+
+    this.Add(Schema, "VimEscNormal", 1, "Mode keys", "boolean"
+      , "ESC to enter the normal mode"
+      , "If checked, pressing ESC enters normal mode.")
+    this.Add(Schema, "VimEscNormalDirect", 1, "Mode keys", "boolean"
+      , "ESC to enter the normal mode directly even if converting in IME"
+      , "If checked, ESC enters normal mode even while IME is converting.`nIf not checked, ESC behaves as normal ESC while IME is converting.")
+    this.Add(Schema, "VimSendEscNormal", 0, "Mode keys", "boolean"
+      , "Send ESC by ESC at the normal mode"
+      , "If checked, a short ESC press sends ESC in normal mode.`nEnable ESC to enter normal mode first.")
+    this.Add(Schema, "VimLongEscNormal", 0, "Mode keys", "boolean"
+      , "Long press ESC to enter the normal mode"
+      , "If checked, short and long press behavior of ESC is swapped.`nEnable ESC to enter normal mode first.")
+    this.Add(Schema, "VimCtrlBracketToEsc", 1, "Mode keys", "boolean"
+      , "Ctrl-[ to ESC"
+      , "If checked, Ctrl-[ behaves as ESC.`nIf Ctrl-[ to normal mode is disabled, Ctrl-[ always sends ESC.`nIf both are checked, long press Ctrl-[ sends ESC.")
+    this.Add(Schema, "VimCtrlBracketNormal", 1, "Mode keys", "boolean"
+      , "Ctrl-[ to enter the normal mode"
+      , "If checked, pressing Ctrl-[ enters normal mode.")
+    this.Add(Schema, "VimCtrlBracketNormalDirect", 1, "Mode keys", "boolean"
+      , "Ctrl-[ to enter the normal mode directly even if converting in IME"
+      , "If checked, Ctrl-[ enters normal mode even while IME is converting.`nIf not checked, Ctrl-[ behaves as ESC while IME is converting.")
+    this.Add(Schema, "VimSendCtrlBracketNormal", 0, "Mode keys", "boolean"
+      , "Send Ctrl-[ by Ctrl-[ at the normal mode"
+      , "If checked, a short Ctrl-[ press sends Ctrl-[ in normal mode.`nEnable Ctrl-[ to enter normal mode first.")
+    this.Add(Schema, "VimLongCtrlBracketNormal", 0, "Mode keys", "boolean"
+      , "Long press Ctrl-[ to enter the normal mode"
+      , "If checked, short and long press behavior of Ctrl-[ is swapped.`nEnable Ctrl-[ to enter normal mode first.")
+    this.Add(Schema, "VimChangeCaretWidth", 0, "Mode keys", "boolean"
+      , "Change to thick text caret when in normal mode"
+      , "If checked, caret width changes by mode (thick in normal/visual, thin in insert).`nIt may not work in all applications and can briefly change window focus.")
+    this.Add(Schema, "VimRestoreIME", 1, "Mode keys", "boolean"
+      , "Restore IME status at entering the insert mode"
+      , "If checked, IME status is saved in insert mode and restored when returning to insert mode.")
+    this.Add(Schema, "VimJJ", 0, "Mode keys", "boolean"
+      , "JJ to enter the normal mode"
+      , "If checked, `jj` enters normal mode from insert mode.")
+    this.Add(Schema, "VimTwoLetter", "", "Mode keys", "list"
+      , "Two-letter to enter the normal mode"
+      , "Two-letter mappings to enter normal mode from insert mode.`nSet one pair per line.`nEach pair must be exactly two different letters.")
+    this.Add(Schema, "VimDisableUnused", 1, "Mode keys", "choice"
+      , "Disable unused keys in the normal mode"
+      , "Disable level for unused keys outside insert mode:`n1: Do not disable unused keys`n2: Disable alphabets (+Shift) and symbols`n3: Disable all, including modified keys (e.g. Ctrl+Z)"
+      , [1, 2, 3])
+
+    this.Add(Schema, "VimSetTitleMatchMode", "2", "Applications", "choice"
+      , "SetTitleMatchMode"
+      , "SetTitleMatchMode mode:`n1: Start with`n2: Contain`n3: Exact match`nRegEx: Regular expression"
+      , ["1", "2", "3", "RegEx"])
+    this.Add(Schema, "VimSetTitleMatchModeFS", "Fast", "Applications", "choice"
+      , "SetTitleMatchMode"
+      , "SetTitleMatchMode speed:`nFast: Text is not detected for some edit controls`nSlow: Works for all windows, but slower"
+      , ["Fast", "Slow"])
+
+    this.Add(Schema, "VimIconCheckInterval", 1000, "Status", "integer"
+      , "Icon check interval (ms)"
+      , "Interval (ms) to check vim_ahk status and update tray icon.`nIf set to 0, the original AHK icon is used."
+      , 0, 0, 1000000)
+    this.Add(Schema, "VimVerbose", 1, "Status", "choice"
+      , "Verbose level"
+      , "Verbose level:`n1: No output`n2: Minimum tooltip (mode only)`n3: Tooltip (all information)`n4: Debug message box (does not auto-close)"
+      , [1, 2, 3, 4])
+
+    this.Add(Schema, "VimAppList", "Allow List", "Applications", "choice"
+      , "Application list usage"
+      , "Application list mode:`nAll: Enable vim_ahk on all applications (ignore the list)`nAllow List: Use list as allow list`nDeny List: Use list as deny list"
+      , ["All", "Allow List", "Deny List"])
+    this.Add(Schema, "VimGroup", DefaultGroup, "Applications", "list"
+      , "Application list"
+      , "Applications where vim_ahk is enabled.`nSet one application per line.`nEach line can be Window Title, Class, or Process.")
+
+    return Schema
+  }
+
+  static Add(Schema, Key, Default, Category, Kind, Description, Info
+      , Choices := 0, Min := "", Max := "") {
+    if !(Choices is Array) {
+      Choices := []
+    }
+    Schema[Key] := Map(
+      "default", Default,
+      "val", Default,
+      "category", Category,
+      "kind", Kind,
+      "description", Description,
+      "info", Info,
+      "choices", Choices,
+      "min", Min,
+      "max", Max)
+  }
+
+  static Values(Schema, Defaults := False) {
+    Values := Map()
+    Field := Defaults ? "default" : "val"
+    for Key, Setting in Schema {
+      Values[Key] := Setting[Field]
+    }
+    return Values
+  }
+
+  static NormalizeValues(Schema, Values, Delimiter) {
+    Normalized := Map()
+    for Key, Setting in Schema {
+      Normalized[Key] := this.Normalize(Setting, Values[Key], Delimiter)
+    }
+    return Normalized
+  }
+
+  static Normalize(Setting, Value, Delimiter) {
+    Kind := Setting["kind"]
+    if (Kind == "boolean") {
+      return Value ? 1 : 0
+    }
+    if (Kind == "integer") {
+      if !IsInteger(Value) {
+        throw ValueError(Setting["description"] " requires an integer.")
+      }
+      Value := Integer(Value)
+      if (Setting["min"] != "" && Value < Setting["min"]) {
+        throw ValueError(Setting["description"] " must be at least " Setting["min"] ".")
+      }
+      if (Setting["max"] != "" && Value > Setting["max"]) {
+        throw ValueError(Setting["description"] " must be at most " Setting["max"] ".")
+      }
+      return Value
+    }
+    if (Kind == "choice") {
+      for Choice in Setting["choices"] {
+        if (Value == Choice) {
+          return Choice
+        }
+      }
+      throw ValueError(Setting["description"] " has an invalid value.")
+    }
+    if (Kind == "list") {
+      return this.NormalizeList(Value, Delimiter)
+    }
+    return Value
+  }
+
+  static NormalizeList(Value, Delimiter) {
+    Value := StrReplace(Value, "`r`n", "`n")
+    Value := StrReplace(Value, "`r", "`n")
+    Value := StrReplace(Value, Delimiter, "`n")
+    Seen := Map()
+    Result := ""
+    Loop Parse, Value, "`n" {
+      Item := Trim(A_LoopField)
+      if (Item != "" && !Seen.Has(Item)) {
+        Seen[Item] := True
+        Result .= (Result == "" ? "" : Delimiter) Item
+      }
+    }
+    return Result
+  }
+}

--- a/lib/vim_state.ahk
+++ b/lib/vim_state.ahk
@@ -104,7 +104,7 @@
 
     if(this.StrIsInCurrentVimMode("Visual") or this.StrIsInCurrentVimMode("ydc")){
       SendInput("{Right}")
-      if WinActive("ahk_group VimCursorSameAfterSelect"){
+      if this.Vim.IsConfiguredGroup("VimCursorSameAfterSelect"){
         SendInput("{Left}")
       }
     }


### PR DESCRIPTION
This PR centralizes all 30 vim_ahk settings into a single schema definition and makes the 10 application behavior groups (VimNonEditor, VimLBSelectGroup, VimShiftEnter, etc.) editable from the Settings GUI.

A new Application group dropdown is added to the Applications tab, below the existing SetTitleMatchMode controls. It lets users switch between VimGroup and the 10 behavior groups, editing each group's application list in a shared multi-line editor. VimAppList (All/Allow List/Deny List) is only shown when VimGroup is selected, since it doesn't apply to behavior groups. VimShiftEnter and VimCtrlEnter are validated as exclusive: the same application cannot appear in both.

On the backend, VimSettingSchema.Build() replaces the 20 AddToConf() calls in vim_ahk.ahk and also holds the default members and metadata for the 10 behavior groups. NormalizeValues() handles type, range, and choice validation for all settings. Initialize() now validates INI values at startup through this path.

The ~30 hardcoded GroupAdd() calls are replaced by SetConfiguredGroups(), which builds AHK window groups dynamically from the current schema values. A new IsConfiguredGroup() method wraps the lookup. 18 call sites across the bind files, vim_move.ahk, and vim_state.ahk are updated from WinActive("ahk_group VimXxx") to this method. Group names and default members are identical to the originals.

In vim_setting.ahk, only the Applications tab's VimAppList + VimGroup section is replaced by the new panel. VimV2Conf() now collects values from both the original controls and the panel, then runs schema validation before committing. OK() and Apply() catch validation errors and display them instead of silently applying bad values. The rest of vim_setting.ahk is original code with original layout.

vim_ini.ahk and vim_gui.ahk are not modified.