### PR TITLE
fix(settings): harden settings and configuration file handling after schema refactoring

### DIFF
--- a/.github/workflows/syntax_check.yml
+++ b/.github/workflows/syntax_check.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Syntax check
+
+jobs:
+  check:
+    name: Syntax check
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Install latest AutoHotkey v2
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $headers = @{ Authorization = "Bearer $env:GITHUB_TOKEN" }
+          $release = Invoke-RestMethod -Uri https://api.github.com/repos/AutoHotkey/AutoHotkey/releases/latest -Headers $headers
+          $asset = $release.assets | Where-Object { $_.name -match '^AutoHotkey_.*\.zip$' } | Select-Object -First 1
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile AutoHotkey.zip
+          Expand-Archive AutoHotkey.zip -DestinationPath AutoHotkey
+      - name: Validate vim.ahk
+        shell: pwsh
+        run: |
+          $p = Start-Process -FilePath .\AutoHotkey\AutoHotkey64.exe -ArgumentList '/ErrorStdOut', '/validate', 'vim.ahk' -Wait -PassThru -NoNewWindow -RedirectStandardOutput validate.log
+          Get-Content validate.log
+          exit $p.ExitCode

--- a/README.md
+++ b/README.md
@@ -144,6 +144,27 @@ All of them can also be changed from the settings GUI.
 |VimAppList|Application list mode:<br><ul><li>All: Enable vim_ahk on all applications (ignore the list).</li><li>Allow List: Use the list as an allow list.</li><li>Deny List: Use the list as a deny list.</li></ul>|Allow List|
 |VimGroup|Applications where vim_ahk is enabled. Set one application per line (Window Title/Class/Process).|See **Applications** section|
 
+In addition, the following options define application lists which change specific behaviors.
+They can be edited in the settings GUI (**Applications** tab, **Application group** dropdown)
+or set in your script like the other options.
+Each list uses the same format as `VimGroup`
+(one application per line in the GUI, comma separated in the script).
+
+|Option|Description|Default|
+|:-----|:----------|:------|
+|VimNonEditor|Enter keeps its native behavior in normal mode and G sends End (instead of Ctrl-End).|Explorer, Q-dir, Chrome, Edge, Firefox, Waterfox, Brave, Vivaldi, Opera|
+|VimLBSelectGroup|Shift+End includes the line break.|PowerPoint, Word, WordPad, Notepad|
+|VimNoLBCopyGroup|Line-wise copy omits the line break.|Evernote|
+|VimCtrlUpDownGroup|Vertical movement uses Ctrl+Up and Ctrl+Down.|OneNote Desktop|
+|VimDoubleHomeGroup|Line-start movement sends Home twice.|Visual Studio Code|
+|VimCaretMove|The `^` command moves to the first non-whitespace character.|(empty)|
+|VimCursorSameAfterSelect|The cursor starts from the same position after selection.|Notepad, Explorer|
+|VimQdir|Q-Dir specific normal-mode bindings are active.|Q-dir|
+|VimShiftEnter|The o and O commands send Shift+Enter to insert a line break.|ChatGPT, Claude, Cursor, Slack, Teams, Discord, WhatsApp, Zoom, Phone Link, LINE|
+|VimCtrlEnter|The o and O commands send Ctrl+Enter to insert a line break.|(empty)|
+
+The same application cannot be set in both `VimShiftEnter` and `VimCtrlEnter`.
+
 Set options before including **vim.ahk** in your script
 inside the auto-execute section, for example:
 
@@ -156,8 +177,9 @@ set these variables before `Vim := VimAhk(A_LineFile)`.
 > [!NOTE]
 > These variables overwrite default values.
 > After checking these variables, the configuration file is read.
-> If you have already run vim_ahk, the configuration file already exists and settings are loaded from it.
-> To apply updated script defaults, use `Reset` in the settings GUI.
+> The configuration file keeps only values changed from the default in the settings GUI,
+> so options you have not changed there follow these variables and script updates.
+> To restore all default values, use `Reset` in the settings GUI, then `OK` or `Apply`.
 
 > [!NOTE]
 > VimIconCheckInterval example

--- a/lib/vim_ahk.ahk
+++ b/lib/vim_ahk.ahk
@@ -64,12 +64,6 @@ class VimAhk{
     this.Initialize()
   }
 
-  SetConfDefault(){
-    for k, v in this.Conf {
-      v["val"] := v["default"]
-    }
-  }
-
   SetExistValue(){
     for k, v in this.Conf {
       if(IsSet(%k%)){
@@ -118,11 +112,17 @@ class VimAhk{
         continue
       }
       GroupName := Group "_" this.ConfiguredGroupN
-      Groups[Group] := GroupName
+      Added := False
       Loop Parse, Setting["val"], this.GroupDel {
         if (A_LoopField != "") {
           GroupAdd(GroupName, A_LoopField)
+          Added := True
         }
+      }
+      ; Groups without any rule are not registered, so that IsConfiguredGroup()
+      ; does not query group names that were never created.
+      if (Added) {
+        Groups[Group] := GroupName
       }
     }
     this.ConfiguredGroups := Groups
@@ -156,11 +156,29 @@ class VimAhk{
     this.__About()
     this.SetExistValue()
     this.Ini.ReadIni()
-    Values := VimSettingSchema.NormalizeValues(
-      this.Conf, VimSettingSchema.Values(this.Conf), this.GroupDel)
+    Warnings := []
+    Values := VimSettingSchema.NormalizeValuesWithFallback(
+      this.Conf, VimSettingSchema.Values(this.Conf), this.GroupDel, Warnings)
+    VimSettingSchema.RepairExclusiveGroups(
+      this.Conf, Values, this.GroupDel, Warnings)
     this.SetValues(Values)
+    ; Rewrite the file so that values equal to the default are removed
+    ; (files written by older versions store every setting) and corrected
+    ; values are persisted.
+    try {
+      this.Ini.WriteIni()
+    } catch {
+      ; Keep the corrected values only in memory if the file cannot be written
+    }
     this.VimMenu.SetMenu()
     this.Setup()
+    if (Warnings.Length > 0) {
+      Message := "Invalid values were found in the configuration file and corrected:"
+      for Warning in Warnings {
+        Message .= "`n`n" Warning
+      }
+      MsgBox(Message, "Vim Ahk", "Icon!")
+    }
   }
 
   SetDefaultActiveWindows(){

--- a/lib/vim_ini.ahk
+++ b/lib/vim_ini.ahk
@@ -65,8 +65,22 @@
       DirCreate(this.IniDir)
 
     for k, v in this.Vim.Conf {
-      IniWrite(v["val"], this.Ini, this.Section, k)
+      ; Keep only non-default values in the file, so that default value updates
+      ; are applied to the settings which have not been changed by the user.
+      if (v["val"] == v["default"]) {
+        try {
+          IniDelete(this.Ini, this.Section, k)
+        } catch OSError {
+          ; The file or the key does not exist
+        }
+      } else {
+        IniWrite(v["val"], this.Ini, this.Section, k)
+      }
     }
+
+    ; Keep the file itself even if all values are default (e.g. for Export)
+    if not FileExist(this.Ini)
+      FileAppend("", this.Ini)
   }
 
   OpenIniDir(Obj, Info){

--- a/lib/vim_setting.ahk
+++ b/lib/vim_setting.ahk
@@ -192,10 +192,12 @@ class VimSetting Extends VimGui{
       path := FileSelect("", "", "Import INI (staged; Apply to confirm)", "INI (*.ini)")
       if (path == "")
         return
-      ; Read selected INI into a temporary conf map without touching runtime conf
+      ; Read selected INI into a temporary conf map without touching runtime conf.
+      ; Values are seeded with the defaults because the INI keeps only
+      ; non-default values: a missing key means the default value.
       tmpConf := Map()
       for k, v in this.Vim.Conf {
-        tmpConf[k] := Map("default", v["default"], "val", v["val"], "description", v["description"], "info", v["info"])
+        tmpConf[k] := Map("default", v["default"], "val", v["default"], "description", v["description"], "info", v["info"])
       }
       SplitPath(path, &fileName, &dir)
       tmpVim := {Conf: tmpConf, GroupDel: this.Vim.GroupDel}

--- a/lib/vim_setting_application_panel.ahk
+++ b/lib/vim_setting_application_panel.ahk
@@ -31,7 +31,7 @@ class VimSettingApplicationPanel {
     this.AddToolTip(this.AppList, AppListSetting["info"])
 
     this.GroupEditor := this.Gui.Add(
-      "Edit", "XS+10 Y+10 R8 W430 Multi VScroll WantTab")
+      "Edit", "XS+10 Y+10 R8 W430 Multi VScroll")
     this.GroupInfo := this.AddLabel("XS+10 Y+8 W430 H48", "")
     this.ApplicationGroup.OnEvent(
       "Change", ObjBindMethod(this, "ApplicationGroupChanged"))
@@ -79,11 +79,12 @@ class VimSettingApplicationPanel {
     if this.Loading {
       return
     }
-    this.SaveCurrentGroup()
     Index := Control.Value
     if (Index < 1 || Index > this.GroupKeys.Length) {
-      throw ValueError("Invalid application group selection.")
+      ; No item is selected; keep the current group
+      return
     }
+    this.SaveCurrentGroup()
     this.ShowGroup(this.GroupKeys[Index])
   }
 

--- a/lib/vim_setting_schema.ahk
+++ b/lib/vim_setting_schema.ahk
@@ -195,6 +195,52 @@ class VimSettingSchema {
     return Normalized
   }
 
+  ; Used at startup so that a broken configuration file cannot prevent launching,
+  ; while OK/Apply in the GUI keep the strict NormalizeValues().
+  static NormalizeValuesWithFallback(Schema, Values, Delimiter, Warnings) {
+    Normalized := Map()
+    for Key, Setting in Schema {
+      try {
+        Normalized[Key] := this.Normalize(Setting, Values[Key], Delimiter)
+      } catch as e {
+        Normalized[Key] := Setting["default"]
+        Warnings.Push(e.Message " The default value is used.")
+      }
+    }
+    return Normalized
+  }
+
+  ; Resolve exclusive-group conflicts by keeping an item in the first setting
+  ; (in schema order) it appears in and removing it from the later ones.
+  ; Used at startup so that a broken configuration file cannot prevent launching.
+  static RepairExclusiveGroups(Schema, Values, Delimiter, Warnings) {
+    Index := Map()
+    for Key, Setting in Schema {
+      for Group in Setting["exclusiveGroups"] {
+        if !Index.Has(Group) {
+          Index[Group] := Map()
+        }
+        Owners := Index[Group]
+        Kept := ""
+        Loop Parse, Values[Key], Delimiter {
+          if (A_LoopField == "") {
+            continue
+          }
+          ItemKey := StrLower(A_LoopField)
+          if (Owners.Has(ItemKey) && Owners[ItemKey] != Key) {
+            Warnings.Push(A_LoopField " was removed from " Setting["description"]
+              . " because it is already set in " Schema[Owners[ItemKey]]["description"] ".")
+            continue
+          }
+          Owners[ItemKey] := Key
+          Kept .= (Kept == "" ? "" : Delimiter) A_LoopField
+        }
+        Values[Key] := Kept
+      }
+    }
+    return Values
+  }
+
   static ValidateExclusiveGroups(Schema, Values, Delimiter) {
     Index := Map()
     for Key, Setting in Schema {
@@ -240,7 +286,10 @@ class VimSettingSchema {
   static Normalize(Setting, Value, Delimiter) {
     Kind := Setting["kind"]
     if (Kind == "boolean") {
-      return Value ? 1 : 0
+      if (Value == 0 || Value == 1) {
+        return Integer(Value)
+      }
+      throw ValueError(Setting["description"] " must be 0 or 1.")
     }
     if (Kind == "integer") {
       if !IsInteger(Value) {


### PR DESCRIPTION
Follow-up to #133, addressing the remaining review feedback (including Copilot comments) on the schema-driven settings.

## Changes

- **Recover from invalid configuration values at startup.** Invalid INI values (wrong booleans, out-of-choice/range values, applications set in both VimShiftEnter and VimCtrlEnter) used to throw an uncaught error in `Initialize()` and abort startup, leaving vim_ahk effectively disabled. Values are now normalized with a per-key fallback to the default, exclusive-group conflicts are repaired deterministically, and a single warning dialog lists what was corrected. OK/Apply in the settings GUI keep the strict validation.
- **Strict boolean validation.** Booleans accept only 0/1 instead of treating any non-empty value as true.
- **Keep only non-default values in the configuration file.** `WriteIni()` deletes keys equal to the default, so future default updates (e.g. new applications in VimShiftEnter) reach users who have saved settings. The startup rewrite migrates configuration files written by older versions, which stored every setting. Import treats a missing key as the default value accordingly.
- **Application group panel robustness.** A selection-change event without a valid selection no longer throws, and `WantTab` is removed from the group editor so Tab moves focus.
- **Cleanups.** Empty application groups are not registered (no `WinActive()` queries on group names that were never created); unused `SetConfDefault()` is removed.
- **Docs.** README documents the 10 application behavior groups, the Application group dropdown, and the new configuration file behavior.
- **CI.** New workflow validates `vim.ahk` with AutoHotkey v2 `/validate` on pull requests and pushes to master (the existing build workflow runs only on tags).

## User-facing impact

- A broken configuration file can no longer prevent vim_ahk from starting; it is corrected with a warning instead.
- Upgrades now update default application lists for users who have saved settings, as long as they have not customized those lists.
- Settings changed via GUI/INI behave as before; the GUI still rejects invalid input with an error dialog.

Relates to #133.